### PR TITLE
Fix tmp location (7f05b76)

### DIFF
--- a/gdown/__init__.py
+++ b/gdown/__init__.py
@@ -86,7 +86,7 @@ def download(url, output, quiet):
 
     tmp_file = tempfile.mktemp(
         suffix=tempfile.template,
-        prefix=output,
+        prefix=osp.basename(output),
         dir=osp.dirname(output),
     )
     try:


### PR DESCRIPTION
The current code caused a FileNotFoundError. e.g. `FileNotFoundError: [Errno 2] No such file or directory: 'checkpoints/checkpoints/2018-02-16_first-model.pth1pep1l0ctmp'` This is because the directory name was prepended twice. `osp.basename` prevents this double directory issue.