### PR TITLE
Proxy support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,8 @@
   Download a large file from Google Drive.
 </h4>
 
-<div align="center">
-  <a href="https://pypi.python.org/pypi/gdown"><img src="https://img.shields.io/pypi/v/gdown.svg"></a>
-  <a href="https://pypi.org/project/gdown"><img src="https://img.shields.io/pypi/pyversions/gdown.svg"></a>
-  <a href="https://github.com/wkentaro/gdown/actions"><img src="https://github.com/wkentaro/gdown/workflows/CI/badge.svg"></a>
-</div>
 
-<div align="center">
-  <img src=".readme/cli.png" width="90%">
-  <img src=".readme/python.png" width="90%">
 </div>
-
-<br/>
 
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@
 
 Download a large file from Google Drive.  
 If you use curl/wget, it fails with a large file because of
-the security warning from Google Drive.  
-Proxy support has been added.
+the security warning from Google Drive.
 
 
 ## Installation
@@ -53,11 +52,6 @@ $ gdown https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c
 $ cat spam.txt
 spam
 
-$ # using a socks proxy
-$ gdown https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c --proxy socks5://127.0.0.1:9050
-$ cat spam.txt
-spam
-
 $ # as an alternative to curl/wget
 $ gdown https://httpbin.org/ip -O ip.json
 $ cat ip.json
@@ -80,7 +74,7 @@ import gdown
 
 url = 'https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c'
 output = 'spam.txt'
-gdown.download(url, output, quiet=False, proxy=None)
+gdown.download(url, output, quiet=False)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,26 @@
   Download a large file from Google Drive.
 </h4>
 
-
+<div align="center">
+  <a href="https://pypi.python.org/pypi/gdown"><img src="https://img.shields.io/pypi/v/gdown.svg"></a>
+  <a href="https://pypi.org/project/gdown"><img src="https://img.shields.io/pypi/pyversions/gdown.svg"></a>
+  <a href="https://github.com/wkentaro/gdown/actions"><img src="https://github.com/wkentaro/gdown/workflows/CI/badge.svg"></a>
 </div>
+
+<div align="center">
+  <img src=".readme/cli.png" width="90%">
+  <img src=".readme/python.png" width="90%">
+</div>
+
+<br/>
 
 
 ## Description
 
 Download a large file from Google Drive.  
 If you use curl/wget, it fails with a large file because of
-the security warning from Google Drive.
+the security warning from Google Drive.  
+Proxy support has been added.
 
 
 ## Installation
@@ -29,7 +40,7 @@ pip install gdown
 ### From Command Line
 
 ```bash
-$ # gdown [-h] [-V] [-O OUTPUT] [-q] [--id] url_or_id
+$ # gdown [-h] [-V] [-O OUTPUT] [-q] [--id] [--proxy PROXY] url_or_id
 
 $ # a large file (~400MB)
 $ gdown https://drive.google.com/uc?id=0B_NiLAzvehC9R2stRmQyM3ZiVjQ
@@ -39,6 +50,11 @@ $ md5sum pose_estimation_2d_chainermodel.pkl
 
 $ # a small file
 $ gdown https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c
+$ cat spam.txt
+spam
+
+$ # using a socks proxy
+$ gdown https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c --proxy socks5://127.0.0.1:9050
 $ cat spam.txt
 spam
 
@@ -64,7 +80,7 @@ import gdown
 
 url = 'https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c'
 output = 'spam.txt'
-gdown.download(url, output, quiet=False)
+gdown.download(url, output, quiet=False, proxy=None)
 ```
 
 

--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -48,7 +48,9 @@ def assert_md5sum(filename, md5, quiet=False, blocksize=None):
         "MD5 doesn't match:\nactual: {}\nexpected: {}".format(md5_actual, md5)
     )
 
-def cached_download(url, path=None, md5=None, quiet=False, postprocess=None, proxy=None):
+
+def cached_download(url, path=None, md5=None, quiet=False,
+                    postprocess=None, proxy=None):
     if path is None:
         path = (
             url.replace('/', '-SLASH-')

--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -48,7 +48,6 @@ def assert_md5sum(filename, md5, quiet=False, blocksize=None):
         "MD5 doesn't match:\nactual: {}\nexpected: {}".format(md5_actual, md5)
     )
 
-# -- (CHANGED) modified function signature --
 def cached_download(url, path=None, md5=None, quiet=False, postprocess=None, proxy=None):
     if path is None:
         path = (
@@ -89,7 +88,6 @@ def cached_download(url, path=None, md5=None, quiet=False, postprocess=None, pro
                 msg = '{}...'.format(msg)
             print(msg, file=sys.stderr)
 
-        # -- (CHANGED) pass proxy parameter as well --
         download(url, temp_path, quiet=quiet, proxy=proxy)
         with filelock.FileLock(lock_path):
             shutil.move(temp_path, path)

--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -48,8 +48,8 @@ def assert_md5sum(filename, md5, quiet=False, blocksize=None):
         "MD5 doesn't match:\nactual: {}\nexpected: {}".format(md5_actual, md5)
     )
 
-
-def cached_download(url, path=None, md5=None, quiet=False, postprocess=None):
+# -- (CHANGED) modified function signature --
+def cached_download(url, path=None, md5=None, quiet=False, postprocess=None, proxy=None):
     if path is None:
         path = (
             url.replace('/', '-SLASH-')
@@ -89,7 +89,8 @@ def cached_download(url, path=None, md5=None, quiet=False, postprocess=None):
                 msg = '{}...'.format(msg)
             print(msg, file=sys.stderr)
 
-        download(url, temp_path, quiet=quiet)
+        # -- (CHANGED) pass proxy parameter as well --
+        download(url, temp_path, quiet=quiet, proxy=proxy)
         with filelock.FileLock(lock_path):
             shutil.move(temp_path, path)
     except Exception:

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -50,7 +50,6 @@ def main():
         action='store_true',
         help='flag to specify file id instead of url',
     )
-
     parser.add_argument(
         '--proxy',
         help='<protocol://host:port> download using the specified proxy',

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -50,6 +50,13 @@ def main():
         action='store_true',
         help='flag to specify file id instead of url',
     )
+
+    # -- (ADDED) add proxy argument --
+    parser.add_argument(
+        '--proxy',
+        help='<protocol://host:port> download using the specified proxy',
+    )
+
     args = parser.parse_args()
 
     if args.output == '-':
@@ -63,7 +70,8 @@ def main():
     else:
         url = args.url_or_id
 
-    download(url=url, output=args.output, quiet=args.quiet)
+    # -- (CHANGED) pass proxy parameter as well --
+    download(url=url, output=args.output, quiet=args.quiet, proxy=args.proxy)
 
 
 if __name__ == '__main__':

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -51,7 +51,6 @@ def main():
         help='flag to specify file id instead of url',
     )
 
-    # -- (ADDED) add proxy argument --
     parser.add_argument(
         '--proxy',
         help='<protocol://host:port> download using the specified proxy',
@@ -70,7 +69,6 @@ def main():
     else:
         url = args.url_or_id
 
-    # -- (CHANGED) pass proxy parameter as well --
     download(url=url, output=args.output, quiet=args.quiet, proxy=args.proxy)
 
 

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -44,8 +44,8 @@ def download(url, output, quiet, proxy):
     sess = requests.session()
 
     if proxy is not None:
-        sess.proxies = {"http": proxy, "https": proxy}
-        print("Using proxy: ", proxy)
+        sess.proxies = {'http': proxy, 'https': proxy}
+        print('Using proxy:', proxy, file=sys.stderr)
 
     file_id, is_download_link = parse_url(url)
 
@@ -53,10 +53,10 @@ def download(url, output, quiet, proxy):
 
         try:
             res = sess.get(url, stream=True)
-        except requests.exceptions.ProxyError as err:
-            print("An error has occurred using proxy %s" % proxy,
+        except requests.exceptions.ProxyError as e:
+            print('An error has occurred using proxy:', proxy,
                   file=sys.stderr)
-            print(str(err), file=sys.stderr)
+            print(e, file=sys.stderr)
             return
 
         if 'Content-Disposition' in res.headers:
@@ -69,7 +69,7 @@ def download(url, output, quiet, proxy):
         url = get_url_from_gdrive_confirmation(res.text)
 
         if url is None:
-            print('Permission denied: %s' % url_origin, file=sys.stderr)
+            print('Permission denied:', url_origin, file=sys.stderr)
             print(
                 "Maybe you need to change permission over "
                 "'Anyone with the link'?",
@@ -89,9 +89,13 @@ def download(url, output, quiet, proxy):
     output_is_path = isinstance(output, six.string_types)
 
     if not quiet:
-        print('Downloading...')
-        print('From:', url_origin)
-        print('To:', osp.abspath(output) if output_is_path else output)
+        print('Downloading...', file=sys.stderr)
+        print('From:', url_origin, file=sys.stderr)
+        print(
+            'To:',
+            osp.abspath(output) if output_is_path else output,
+            file=sys.stderr,
+        )
 
     if output_is_path:
         tmp_file = tempfile.mktemp(

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -39,12 +39,10 @@ def get_url_from_gdrive_confirmation(contents):
             return url
 
 
-# -- (CHANGED) modified function signature --
 def download(url, output, quiet, proxy):
     url_origin = url
     sess = requests.session()
 
-    # -- (ADDED) assign a proxy dictionary to the request session
     if proxy is not None:
         sess.proxies = {"http": proxy,
                         "https": proxy}
@@ -54,7 +52,6 @@ def download(url, output, quiet, proxy):
 
     while True:
 
-        # -- (CHANGED) cache proxy exception
         try:
             res = sess.get(url, stream=True)
         except requests.exceptions.ProxyError as err:

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -44,8 +44,7 @@ def download(url, output, quiet, proxy):
     sess = requests.session()
 
     if proxy is not None:
-        sess.proxies = {"http": proxy,
-                        "https": proxy}
+        sess.proxies = {"http": proxy, "https": proxy}
         print("Using proxy: ", proxy)
 
     file_id, is_download_link = parse_url(url)

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -55,7 +55,8 @@ def download(url, output, quiet, proxy):
         try:
             res = sess.get(url, stream=True)
         except requests.exceptions.ProxyError as err:
-            print("An error has occurred using proxy %s" % proxy, file=sys.stderr)
+            print("An error has occurred using proxy %s" % proxy,
+                  file=sys.stderr)
             print(str(err), file=sys.stderr)
             return
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     name='gdown',
     version=version,
     packages=find_packages(),
-    install_requires=['filelock', 'requests', 'six', 'tqdm', 'pysocks'],
+    install_requires=['filelock', 'requests[socks]', 'six', 'tqdm'],
     description='Google Drive direct download of big files.',
     long_description=get_long_description(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     name='gdown',
     version=version,
     packages=find_packages(),
-    install_requires=['filelock', 'requests', 'six', 'tqdm'],
+    install_requires=['filelock', 'requests', 'six', 'tqdm', 'pysocks'],  # -- (ADDED) add `pysocks` library
     description='Google Drive direct download of big files.',
     long_description=get_long_description(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     name='gdown',
     version=version,
     packages=find_packages(),
-    install_requires=['filelock', 'requests', 'six', 'tqdm', 'pysocks'],  # -- (ADDED) add `pysocks` library
+    install_requires=['filelock', 'requests', 'six', 'tqdm', 'pysocks'],
     description='Google Drive direct download of big files.',
     long_description=get_long_description(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Dear Kentaro Wada,

I have added a proxy support for gdown simply by passing a proxy argument from command line to the request library. Therefore, it should support the common proxy types (including the socks and https).
Hope it helps.