### PR TITLE
Fix download for when proxy is not passed for backward compatibility

### DIFF
--- a/gdown/download.py
+++ b/gdown/download.py
@@ -39,7 +39,7 @@ def get_url_from_gdrive_confirmation(contents):
             return url
 
 
-def download(url, output, quiet, proxy):
+def download(url, output, quiet, proxy=None):
     url_origin = url
     sess = requests.session()
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,11 @@
+from gdown.download import download
+import os
+
+
+def test_download():
+    url = 'https://raw.githubusercontent.com/wkentaro/gdown/3.1.0/gdown/__init__.py'  # NOQA
+    output = '/tmp/gdown_r'
+
+    # Usage before https://github.com/wkentaro/gdown/pull/32
+    assert download(url, output, quiet=False) == output
+    os.remove(output)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,5 +1,6 @@
-from gdown.download import download
 import os
+
+from gdown.download import download
 
 
 def test_download():


### PR DESCRIPTION
This PR includes #34 

#32 breaks existing codes using gdown:
```
  File "/home/pazeshun/apc_test_ws/src/jsk_apc/demos/grasp_fusion/ros/grasp_fusion/python/grasp_fusion_lib/data/utils.py", line 95, in download
    gdown.download(url, temp_path, quiet=quiet)
TypeError: download() takes exactly 4 arguments (3 given)
```
This is because existing codes pass 3 arguments to download function while #32 adds new required argument `proxy`.

This PR fixes that by adding default value to proxy.