### PR TITLE
Add initial support for folder downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         output=/tmp/folder
         gdown https://drive.google.com/drive/folders/1ZXEhzbLRLU1giKKRJkjm8N04cO_JoYE2 -O $output --quiet --folder
         sudo apt install tree
-        test "$(tree $output | tail -1)" = '7 directories, 51 files'
+        test '$(tree $output | tail -1)' = '7 directories, 51 files'
         rm -rf $output
 
     - name: Install from dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       run: |
         output = /tmp/folder
         gdown https://drive.google.com/drive/folders/1ZXEhzbLRLU1giKKRJkjm8N04cO_JoYE2 -O $output --quiet --folder
-        test (tree $output | tail -1) = '7 directories, 51 files'
+        test $(tree $output | tail -1) = '7 directories, 51 files'
         rm -rf $output
 
     - name: Install from dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
       run: |
         output=/tmp/folder
         gdown https://drive.google.com/drive/folders/1ZXEhzbLRLU1giKKRJkjm8N04cO_JoYE2 -O $output --quiet --folder
+        sudo apt install tree
         test $(tree $output | tail -1) = '7 directories, 51 files'
         rm -rf $output
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
     - name: Download folder from Google Drive
       run: |
-        output = /tmp/folder
+        output=/tmp/folder
         gdown https://drive.google.com/drive/folders/1ZXEhzbLRLU1giKKRJkjm8N04cO_JoYE2 -O $output --quiet --folder
         test $(tree $output | tail -1) = '7 directories, 51 files'
         rm -rf $output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         output=/tmp/folder
         gdown https://drive.google.com/drive/folders/1ZXEhzbLRLU1giKKRJkjm8N04cO_JoYE2 -O $output --quiet --folder
         sudo apt install tree
-        test $(tree $output | tail -1) = '7 directories, 51 files'
+        test "$(tree $output | tail -1)" = '7 directories, 51 files'
         rm -rf $output
 
     - name: Install from dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,18 +66,25 @@ jobs:
         test $(md5sum $output | awk '{print $1}') = 2a51927dde6b146ce56b4d89ebbb5268
         rm -rf $output
 
-    - name: Download small file from Gdrive
+    - name: Download small file from Google Drive
       run: |
         output=/tmp/spam.txt
         gdown https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c -O $output --quiet
         test $(cat $output) = spam
         rm -rf $output
 
-    - name: Download large file from Gdrive
+    - name: Download large file from Google Drive
       run: |
         output=/tmp/20150428_collected_images.tgz
         gdown https://drive.google.com/uc?id=0B9P1L--7Wd2vNm9zMTJWOGxobkU -O $output --quiet
         test $(md5sum $output | awk '{print $1}') = fa837a88f0c40c513d975104edf3da17
+        rm -rf $output
+
+    - name: Download folder from Google Drive
+      run: |
+        output = /tmp/folder
+        gdown https://drive.google.com/drive/folders/1ZXEhzbLRLU1giKKRJkjm8N04cO_JoYE2 -O $output --quiet --folder
+        test (tree $output | tail -1) = '7 directories, 51 files'
         rm -rf $output
 
     - name: Install from dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,9 @@ jobs:
 
     - name: Download folder from Google Drive
       run: |
-        output=/tmp/folder
-        gdown https://drive.google.com/drive/folders/1ZXEhzbLRLU1giKKRJkjm8N04cO_JoYE2 -O $output --quiet --folder
         sudo apt install tree
+        output=/tmp/folder
+        gdown https://drive.google.com/drive/folders/1ivUsJd88C8rl4UpqpxIcdI5YLmRD0Mfj -O $output --quiet --folder
         test '$(tree $output | tail -1)' = '7 directories, 51 files'
         rm -rf $output
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pip install gdown
 
 ```bash
 $ gdown --help
-usage: gdown [-h] [-V] [-O OUTPUT] [-q] [--id] [--proxy PROXY] [--speed SPEED]
+usage: gdown [-h] [-V] [-O OUTPUT] [-q] [--id] [--folder] [--proxy PROXY] [--speed SPEED]
              [--no-cookies]
              url_or_id
 ...
@@ -55,6 +55,9 @@ $ # a small file
 $ gdown https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c
 $ cat spam.txt
 spam
+
+$ # a folder
+$ gdown https://drive.google.com/drive/folders/1ivUsJd88C8rl4UpqpxIcdI5YLmRD0Mfj -O /temp/folder --folder
 
 $ # as an alternative to curl/wget
 $ gdown https://httpbin.org/ip -O ip.json
@@ -82,6 +85,9 @@ gdown.download(url, output, quiet=False)
 
 md5 = 'fa837a88f0c40c513d975104edf3da17'
 gdown.cached_download(url, output, md5=md5, postprocess=gdown.extractall)
+
+url = 'https://drive.google.com/drive/folders/1ivUsJd88C8rl4UpqpxIcdI5YLmRD0Mfj'
+gdown.download_folder(url, quiet=True, no_cookies=True)
 ```
 
 

--- a/gdown/__init__.py
+++ b/gdown/__init__.py
@@ -2,6 +2,7 @@
 
 import pkg_resources
 
+from .download_folder import download_folder
 from .cached_download import cached_download
 from .cached_download import md5sum
 from .download import download

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -58,7 +58,7 @@ def main():
         help="display version",
     )
     parser.add_argument(
-        "url_or_id", help="url or file/folder id (with --id) to download file/folder from"
+        "url_or_id", help="url or file/folder id (with --id) to download from"
     )
     parser.add_argument("-O", "--output", help="output filename")
     parser.add_argument(
@@ -103,7 +103,7 @@ def main():
         url = "https://drive.google.com/folders/{id}".format(id=args.url_or_id)
     else:
         url = args.url_or_id
-    
+
     if args.folder:
         download_folder(
             url=url,
@@ -120,6 +120,7 @@ def main():
             speed=args.speed,
             use_cookies=not args.no_cookies,
         )
+
 
 if __name__ == "__main__":
     main()

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -60,7 +60,7 @@ def main():
     parser.add_argument(
         "url_or_id", help="url or file/folder id (with --id) to download from"
     )
-    parser.add_argument("-O", "--output", help="output filename")
+    parser.add_argument("-O", "--output", help="output file name / path")
     parser.add_argument(
         "-q", "--quiet", action="store_true", help="suppress standard output"
     )
@@ -107,9 +107,11 @@ def main():
     if args.folder:
         download_folder(
             url=url,
+            output=args.output,
             quiet=args.quiet,
             proxy=args.proxy,
             speed=args.speed,
+            use_cookies=not args.no_cookies,
         )
     else:
         download(

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -106,7 +106,7 @@ def main():
 
     if args.folder:
         download_folder(
-            url=url,
+            url,
             output=args.output,
             quiet=args.quiet,
             proxy=args.proxy,

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -76,7 +76,7 @@ def main():
     parser.add_argument(
         "--speed",
         type=file_size,
-        help="download speed limit in second (e.g., '10MB' -> 10MB/s).",
+        help="download speed limit in second (e.g., '10MB' -> 10MB/s)",
     )
     parser.add_argument(
         "--no-cookies",
@@ -86,7 +86,7 @@ def main():
     parser.add_argument(
         "--folder",
         action="store_true",
-        help="download entire folder instead of a single file.",
+        help="download entire folder instead of a single file",
     )
 
     args = parser.parse_args()

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -8,6 +8,7 @@ import pkg_resources
 import six
 
 from .download import download
+from .download_folder import download_folder
 
 distribution = pkg_resources.get_distribution("gdown")
 
@@ -57,7 +58,7 @@ def main():
         help="display version",
     )
     parser.add_argument(
-        "url_or_id", help="url or file id (with --id) to download file from"
+        "url_or_id", help="url or file/folder id (with --id) to download file/folder from"
     )
     parser.add_argument("-O", "--output", help="output filename")
     parser.add_argument(
@@ -66,7 +67,7 @@ def main():
     parser.add_argument(
         "--id",
         action="store_true",
-        help="flag to specify file id instead of url",
+        help="flag to specify file/folder id instead of url",
     )
     parser.add_argument(
         "--proxy",
@@ -82,6 +83,11 @@ def main():
         action="store_true",
         help="don't use cookies in ~/.cache/gdown/cookies.json",
     )
+    parser.add_argument(
+        "--folder",
+        action="store_true",
+        help="download entire folder instead of a single file.",
+    )
 
     args = parser.parse_args()
 
@@ -91,20 +97,29 @@ def main():
         else:
             args.output = sys.stdout
 
-    if args.id:
+    if args.id and not args.folder:
         url = "https://drive.google.com/uc?id={id}".format(id=args.url_or_id)
+    elif args.id and args.folder:
+        url = "https://drive.google.com/folders/{id}".format(id=args.url_or_id)
     else:
         url = args.url_or_id
-
-    download(
-        url=url,
-        output=args.output,
-        quiet=args.quiet,
-        proxy=args.proxy,
-        speed=args.speed,
-        use_cookies=not args.no_cookies,
-    )
-
+    
+    if args.folder:
+        download_folder(
+            url=url,
+            quiet=args.quiet,
+            proxy=args.proxy,
+            speed=args.speed,
+        )
+    else:
+        download(
+            url=url,
+            output=args.output,
+            quiet=args.quiet,
+            proxy=args.proxy,
+            speed=args.speed,
+            use_cookies=not args.no_cookies,
+        )
 
 if __name__ == "__main__":
     main()

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -6,10 +6,10 @@ import sys
 
 if sys.version_info.major < 3:
     from pathlib2 import Path
-    from pathlib2 import PurePath
 else:
     from pathlib import Path
-    from pathlib import PurePath
+
+folder_root = Path()
 
 client = requests.session()
 

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -4,6 +4,8 @@ from bs4 import BeautifulSoup
 import pathlib
 import requests
 
+print(pathlib.__version__)
+
 client = requests.session()
 
 

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -6,7 +6,9 @@ import requests
 client = requests.session()
 
 
-def download_folder(folder, quiet=False, proxy=None, speed=None):
+def download_folder(
+    folder, quiet=False, proxy=None, speed=None, use_cookies=True
+):
     """Download entire folder from URL.
 
     Parameters
@@ -20,17 +22,15 @@ def download_folder(folder, quiet=False, proxy=None, speed=None):
         Proxy.
     speed: float, optional
         Download byte size per second (e.g., 256KB/s = 256 * 1024).
-
-    Returns
-    -------
-    output: str
-        Output filename.
+    use_cookies: bool
+        Flag to use cookies. Default is True.
 
     Example
     -------
     gdown.download_folder(
         "https://drive.google.com/drive/folders/" +
-        "1ZXEhzbLRLU1giKKRJkjm8N04cO_JoYE2"
+        "1ZXEhzbLRLU1giKKRJkjm8N04cO_JoYE2",
+        use_cookies=True
     )
     """
     folders_url = "https://drive.google.com/drive/folders/"
@@ -39,6 +39,9 @@ def download_folder(folder, quiet=False, proxy=None, speed=None):
     folder_soup = BeautifulSoup(
         client.get(folder).text, features="html.parser"
     )
+
+    if not use_cookies:
+        client.cookies.clear()
 
     # finds the script tag with window['_DRIVE_ivd']
     # in it and extracts the encoded array
@@ -65,6 +68,7 @@ def download_folder(folder, quiet=False, proxy=None, speed=None):
                 quiet=True,
                 proxy=proxy,
                 speed=speed,
+                use_cookies=use_cookies,
             )
             if not quiet:
                 print(
@@ -82,4 +86,5 @@ def download_folder(folder, quiet=False, proxy=None, speed=None):
                 quiet=quiet,
                 proxy=proxy,
                 speed=speed,
+                use_cookies=use_cookies,
             )

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -198,7 +198,7 @@ def download_folder(
         file[1].parent.mkdir(parents=True, exist_ok=True)
 
         return_code = download(
-            file[0],
+            files_url+file[0],
             output=str(file[1]),
             quiet=quiet,
             proxy=proxy,

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -1,10 +1,15 @@
 from .download import download
 import ast
 from bs4 import BeautifulSoup
-import pathlib
 import requests
+import sys
 
-print(pathlib.__version__)
+if sys.version_info.major < 3:
+    from pathlib2 import Path
+    from pathlib2 import PurePath
+else:
+    from pathlib import Path
+    from pathlib import PurePath
 
 client = requests.session()
 

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -1,0 +1,56 @@
+from bs4 import BeautifulSoup
+from .download import download
+import requests, ast
+
+client = requests.session()
+
+def download_folder(folder, quiet = False, proxy = None, speed = None):
+    """
+    Download entire folder from URL.
+
+    Parameters
+    ----------
+
+    url: str
+        URL of the Google Drive folder. Must be of the format 'https://drive.google.com/drive/folders/{url}'
+    quiet: bool, optional
+        Suppress terminal output.
+    proxy: str, optional
+        Proxy.
+    speed: float, optional
+        Download byte size per second (e.g., 256KB/s = 256 * 1024).
+
+    Returns
+    -------
+
+    output: str
+        Output filename.
+
+    Example
+    -------
+
+    gdown.download_folder("https://drive.google.com/drive/folders/1ZXEhzbLRLU1giKKRJkjm8N04cO_JoYE2")
+
+    """
+
+    folder_soup = BeautifulSoup(client.get(folder).text, features = "html.parser")
+
+    # finds the script tag with window['_DRIVE_ivd'] in it and extracts the encoded array
+    byte_string = folder_soup.find_all('script')[-3].contents[0][24:-113] 
+
+    # decodes the array and evaluates it as a python array
+    folder_arr = ast.literal_eval(byte_string.replace('\\/', "/").encode('utf-8').decode('unicode-escape').replace("\n", "").replace('null', '"null"'))
+
+    folder_file_list = [i[0] for i in folder_arr[0]]
+    folder_name_list = [i[2] for i in folder_arr[0]]
+    folder_type_list = [i[3] for i in folder_arr[0]]
+
+    for file in range(len(folder_file_list)):
+        if folder_type_list[file] != "application/vnd.google-apps.folder":
+            download("https://drive.google.com/uc?id=" + folder_file_list[file], folder_name_list[file], quiet = True, proxy = proxy, speed = speed)
+            if quiet == False:
+                print("https://drive.google.com/uc?id=" + folder_file_list[file], folder_name_list[file])
+        else:
+            if quiet == False:
+                print("Processing folder", folder_name_list[file], "(https://drive.google.com/drive/folders/" + folder_file_list[file] + ")")
+            download_folder("https://drive.google.com/drive/folders/" + folder_file_list[file], quiet = quiet, proxy = proxy, speed = speed)

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -8,16 +8,15 @@ if sys.version_info.major < 3:
     from pathlib2 import Path
 else:
     from pathlib import Path
-
-folder_root = Path()
-
 client = requests.session()
 
+folders_url = "https://drive.google.com/drive/folders/"
+files_url = "https://drive.google.com/uc?id="
+folder_type = "application/vnd.google-apps.folder"
 
-def download_folder(
-    folder, quiet=False, proxy=None, speed=None, use_cookies=True
-):
-    """Download entire folder from URL.
+
+def get_folder_list(folder, quiet=False, use_cookies=True):
+    """Get folder structure of Google Drive folder URL.
 
     Parameters
     ----------
@@ -26,11 +25,7 @@ def download_folder(
         Must be of the format 'https://drive.google.com/drive/folders/{url}'.
     quiet: bool, optional
         Suppress terminal output.
-    proxy: str, optional
-        Proxy.
-    speed: float, optional
-        Download byte size per second (e.g., 256KB/s = 256 * 1024).
-    use_cookies: bool
+    use_cookies: bool, optional
         Flag to use cookies. Default is True.
 
     Returns
@@ -39,22 +34,11 @@ def download_folder(
         Returns False if the download completed unsuccessfully.
         May be due to invalid URLs, permission errors, rate limits, etc.
     folder_list: dict
-        Returns the directory structure of the folder.
-
-    Example
-    -------
-    gdown.download_folder(
-        "https://drive.google.com/drive/folders/" +
-        "1ZXEhzbLRLU1giKKRJkjm8N04cO_JoYE2",
-        use_cookies=True
-    )
+        Returns the folder structure of the Google Drive folder.
     """
     return_code = True
 
     folder_list = {}
-
-    folders_url = "https://drive.google.com/drive/folders/"
-    files_url = "https://drive.google.com/uc?id="
 
     folder_page = client.get(folder)
 
@@ -77,9 +61,9 @@ def download_folder(
         .replace("null", '"null"')
     )
 
-    folder_list["file_name"] = folder_soup.title.contents
+    folder_list["file_name"] = folder_soup.title.contents[0][:-15]
     folder_list["file_id"] = folder[39:]
-    folder_list["file_type"] = "application/vnd.google-apps.folder"
+    folder_list["file_type"] = folder_type
     folder_list["file_contents"] = []
 
     folder_file_list = [i[0] for i in folder_arr[0]]
@@ -87,7 +71,13 @@ def download_folder(
     folder_type_list = [i[3] for i in folder_arr[0]]
 
     for file in range(len(folder_file_list)):
-        if folder_type_list[file] != "application/vnd.google-apps.folder":
+        if folder_type_list[file] != folder_type:
+            if not quiet:
+                print(
+                    "Processing file",
+                    folder_file_list[file],
+                    folder_name_list[file],
+                )
             folder_list["file_contents"].append(
                 {
                     "file_name": folder_name_list[file],
@@ -96,35 +86,130 @@ def download_folder(
                     "file_contents": None,
                 }
             )
-            return_code = download(
-                files_url + folder_file_list[file],
-                output=folder_name_list[file],
-                quiet=True,
-                proxy=proxy,
-                speed=speed,
-                use_cookies=use_cookies,
-            )
-            if not quiet:
-                print(
-                    files_url + folder_file_list[file], folder_name_list[file]
-                )
             if not return_code:
                 return return_code, None
         else:
             if not quiet:
                 print(
-                    "Processing folder",
+                    "Retrieving folder",
+                    folder_file_list[file],
                     folder_name_list[file],
-                    "(" + folders_url + folder_file_list[file] + ")",
                 )
-            return_code, directory_structure = download_folder(
+            return_code, folder_structure = get_folder_list(
                 folders_url + folder_file_list[file],
-                quiet=quiet,
-                proxy=proxy,
-                speed=speed,
                 use_cookies=use_cookies,
             )
             if not return_code:
                 return return_code, None
-            folder_list["file_contents"].append(directory_structure)
+            folder_list["file_contents"].append(folder_structure)
     return return_code, folder_list
+
+
+def get_directory_structure(directory, previous_path):
+    """Converts a Google Drive folder structure into a local directory list.
+
+    Parameters
+    ----------
+    directory: dict
+        Dictionary containing the Google Drive folder structure.
+    previous_path: pathlib.Path
+        Path containing the parent's file path.
+
+    Returns
+    -------
+    directory_structure: list
+        List containing a tuple of the files' ID and file path.
+    """
+    directory_structure = []
+    for file in directory["file_contents"]:
+        if file["file_type"] == folder_type:
+            for i in get_directory_structure(
+                file, previous_path / file["file_name"]
+            ):
+                directory_structure.append(i)
+        elif file["file_contents"] is None:
+            directory_structure.append(
+                (file["file_id"], previous_path / file["file_name"])
+            )
+    return directory_structure
+
+
+def download_folder(
+    folder, output=None, quiet=False, proxy=None, speed=None, use_cookies=True
+):
+    """Downloads entire folder from URL.
+
+    Parameters
+    ----------
+    url: str
+        URL of the Google Drive folder.
+        Must be of the format 'https://drive.google.com/drive/folders/{url}'.
+    output: str, optional
+        String containing the path of the output folder.
+        Defaults to current working directory.
+    quiet: bool, optional
+        Suppress terminal output.
+    proxy: str, optional
+        Proxy.
+    speed: float, optional
+        Download byte size per second (e.g., 256KB/s = 256 * 1024).
+    use_cookies: bool, optional
+        Flag to use cookies. Default is True.
+
+    Returns
+    -------
+    return_code: bool
+        Returns False if the download completed unsuccessfully.
+        May be due to invalid URLs, permission errors, rate limits, etc.
+
+    Example
+    -------
+    gdown.download_folder(
+        "https://drive.google.com/drive/folders/" +
+        "1ZXEhzbLRLU1giKKRJkjm8N04cO_JoYE2",
+        use_cookies=True
+    )
+    """
+    if not quiet:
+        print("Retrieving folder list")
+    return_code, folder_list = get_folder_list(
+        folder,
+        quiet=quiet,
+        use_cookies=False,
+    )
+
+    if not return_code:
+        return return_code
+    if not quiet:
+        print("Retrieving folder list completed")
+        print("Building directory structure")
+    if output is None:
+        output = Path.cwd()
+    else:
+        output = Path(output)
+    directory_structure = get_directory_structure(
+        folder_list,
+        output / folder_list["file_name"],
+    )
+
+    if not quiet:
+        print("Building directory structure completed")
+    for file in directory_structure:
+        file[1].parent.mkdir(parents=True, exist_ok=True)
+
+        return_code = download(
+            file[0],
+            output=str(file[1]),
+            quiet=quiet,
+            proxy=proxy,
+            speed=speed,
+            use_cookies=use_cookies,
+        )
+
+        if not return_code:
+            if not quiet:
+                print("Download ended unsuccessfully")
+            return return_code
+    if return_code and not quiet:
+        print("Download completed")
+    return return_code

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -1,6 +1,6 @@
 from .download import download
-from bs4 import BeautifulSoup
 import ast
+from bs4 import BeautifulSoup
 import requests
 
 client = requests.session()
@@ -12,7 +12,6 @@ def download_folder(folder, quiet=False, proxy=None, speed=None):
 
     Parameters
     ----------
-
     url: str
         URL of the Google Drive folder.
         Must be of the format 'https://drive.google.com/drive/folders/{url}'
@@ -25,20 +24,17 @@ def download_folder(folder, quiet=False, proxy=None, speed=None):
 
     Returns
     -------
-
     output: str
         Output filename.
 
     Example
     -------
-
     gdown.download_folder(
         "https://drive.google.com/drive/folders/" +
         "1ZXEhzbLRLU1giKKRJkjm8N04cO_JoYE2"
     )
-
     """
-    
+
     folders_url = "https://drive.google.com/drive/folders/"
     files_url = "https://drive.google.com/uc?id="
 
@@ -53,8 +49,7 @@ def download_folder(folder, quiet=False, proxy=None, speed=None):
 
     # decodes the array and evaluates it as a python array
     folder_arr = ast.literal_eval(byte_string.replace('\\/', "/")
-        .encode('utf-8')
-        .decode('unicode-escape')
+        .encode('utf-8').decode('unicode-escape')
         .replace("\n", "")
         .replace('null', '"null"')
     )

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -6,11 +6,8 @@ import requests
 client = requests.session()
 
 
-def download_folder(
-    folder, quiet=False, proxy=None, speed=None
-):
+def download_folder(folder, quiet=False, proxy=None, speed=None):
     """Download entire folder from URL.
-
     Parameters
     ----------
     url: str
@@ -22,12 +19,10 @@ def download_folder(
         Proxy.
     speed: float, optional
         Download byte size per second (e.g., 256KB/s = 256 * 1024).
-
     Returns
     -------
     output: str
         Output filename.
-
     Example
     -------
     gdown.download_folder(
@@ -38,21 +33,19 @@ def download_folder(
     folders_url = "https://drive.google.com/drive/folders/"
     files_url = "https://drive.google.com/uc?id="
 
-    folder_soup = BeautifulSoup(
-        client.get(folder).text,
-        features="html.parser"
-    )
+    folder_soup = BeautifulSoup(client.get(folder).text, features="html.parser")
 
     # finds the script tag with window['_DRIVE_ivd']
     # in it and extracts the encoded array
-    byte_string = folder_soup.find_all('script')[-3].contents[0][24:-113]
+    byte_string = folder_soup.find_all("script")[-3].contents[0][24:-113]
 
     # decodes the array and evaluates it as a python array
     folder_arr = ast.literal_eval(
-        byte_string.replace('\\/', "/")
-        .encode('utf-8').decode('unicode-escape')
+        byte_string.replace("\\/", "/")
+        .encode("utf-8")
+        .decode("unicode-escape")
         .replace("\n", "")
-        .replace('null', '"null"')
+        .replace("null", '"null"')
     )
 
     folder_file_list = [i[0] for i in folder_arr[0]]
@@ -66,22 +59,22 @@ def download_folder(
                 output=folder_name_list[file],
                 quiet=True,
                 proxy=proxy,
-                speed=speed
+                speed=speed,
             )
             if not quiet:
                 print(
-                    files_url + folder_file_list[file],
-                    folder_name_list[file]
+                    files_url + folder_file_list[file], folder_name_list[file]
                 )
         else:
             if not quiet:
                 print(
-                    "Processing folder", folder_name_list[file],
-                    "(" + folders_url + folder_file_list[file] + ")"
+                    "Processing folder",
+                    folder_name_list[file],
+                    "(" + folders_url + folder_file_list[file] + ")",
                 )
             download_folder(
                 folders_url + folder_file_list[file],
                 quiet=quiet,
                 proxy=proxy,
-                speed=speed
+                speed=speed,
             )

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -198,7 +198,7 @@ def download_folder(
         file[1].parent.mkdir(parents=True, exist_ok=True)
 
         return_code = download(
-            files_url+file[0],
+            files_url + file[0],
             output=str(file[1]),
             quiet=quiet,
             proxy=proxy,

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -1,6 +1,7 @@
 from .download import download
 import ast
 from bs4 import BeautifulSoup
+import pathlib
 import requests
 
 client = requests.session()

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -13,7 +13,7 @@ def download_folder(folder, quiet=False, proxy=None, speed=None):
     ----------
     url: str
         URL of the Google Drive folder.
-        Must be of the format 'https://drive.google.com/drive/folders/{url}'
+        Must be of the format 'https://drive.google.com/drive/folders/{url}'.
     quiet: bool, optional
         Suppress terminal output.
     proxy: str, optional

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -8,6 +8,7 @@ client = requests.session()
 
 def download_folder(folder, quiet=False, proxy=None, speed=None):
     """Download entire folder from URL.
+
     Parameters
     ----------
     url: str
@@ -19,10 +20,12 @@ def download_folder(folder, quiet=False, proxy=None, speed=None):
         Proxy.
     speed: float, optional
         Download byte size per second (e.g., 256KB/s = 256 * 1024).
+
     Returns
     -------
     output: str
         Output filename.
+
     Example
     -------
     gdown.download_folder(
@@ -33,7 +36,9 @@ def download_folder(folder, quiet=False, proxy=None, speed=None):
     folders_url = "https://drive.google.com/drive/folders/"
     files_url = "https://drive.google.com/uc?id="
 
-    folder_soup = BeautifulSoup(client.get(folder).text, features="html.parser")
+    folder_soup = BeautifulSoup(
+        client.get(folder).text, features="html.parser"
+    )
 
     # finds the script tag with window['_DRIVE_ivd']
     # in it and extracts the encoded array

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -1,13 +1,13 @@
-from bs4 import BeautifulSoup
 from .download import download
-import requests
+from bs4 import BeautifulSoup
 import ast
+import requests
 
 client = requests.session()
 
+
 def download_folder(folder, quiet=False, proxy=None, speed=None):
     """
-    
     Download entire folder from URL.
 
     Parameters
@@ -38,6 +38,9 @@ def download_folder(folder, quiet=False, proxy=None, speed=None):
     )
 
     """
+    
+    folders_url = "https://drive.google.com/drive/folders/"
+    files_url = "https://drive.google.com/uc?id="
 
     folder_soup = BeautifulSoup(
         client.get(folder).text,
@@ -46,7 +49,7 @@ def download_folder(folder, quiet=False, proxy=None, speed=None):
 
     # finds the script tag with window['_DRIVE_ivd']
     # in it and extracts the encoded array
-    byte_string = folder_soup.find_all('script')[-3].contents[0][24:-113] 
+    byte_string = folder_soup.find_all('script')[-3].contents[0][24:-113]
 
     # decodes the array and evaluates it as a python array
     folder_arr = ast.literal_eval(byte_string.replace('\\/', "/")
@@ -63,7 +66,7 @@ def download_folder(folder, quiet=False, proxy=None, speed=None):
     for file in range(len(folder_file_list)):
         if folder_type_list[file] != "application/vnd.google-apps.folder":
             download(
-                "https://drive.google.com/uc?id=" + folder_file_list[file],
+                files_url + folder_file_list[file],
                 output=folder_name_list[file],
                 quiet=True,
                 proxy=proxy,
@@ -71,19 +74,17 @@ def download_folder(folder, quiet=False, proxy=None, speed=None):
             )
             if not quiet:
                 print(
-                    "https://drive.google.com/uc?id=" + folder_file_list[file],
+                    files_url + folder_file_list[file],
                     folder_name_list[file]
                 )
         else:
             if not quiet:
                 print(
                     "Processing folder", folder_name_list[file],
-                    "(https://drive.google.com/drive/folders/" +
-                    folder_file_list[file] + ")"
+                    "(" + folders_url + folder_file_list[file] + ")"
                 )
             download_folder(
-                "https://drive.google.com/drive/folders/" +
-                folder_file_list[file],
+                folders_url + folder_file_list[file],
                 quiet=quiet,
                 proxy=proxy,
                 speed=speed

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -6,9 +6,10 @@ import requests
 client = requests.session()
 
 
-def download_folder(folder, quiet=False, proxy=None, speed=None):
-    """
-    Download entire folder from URL.
+def download_folder(
+    folder, quiet=False, proxy=None, speed=None
+):
+    """Download entire folder from URL.
 
     Parameters
     ----------
@@ -34,7 +35,6 @@ def download_folder(folder, quiet=False, proxy=None, speed=None):
         "1ZXEhzbLRLU1giKKRJkjm8N04cO_JoYE2"
     )
     """
-
     folders_url = "https://drive.google.com/drive/folders/"
     files_url = "https://drive.google.com/uc?id="
 

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -48,7 +48,8 @@ def download_folder(
     byte_string = folder_soup.find_all('script')[-3].contents[0][24:-113]
 
     # decodes the array and evaluates it as a python array
-    folder_arr = ast.literal_eval(byte_string.replace('\\/', "/")
+    folder_arr = ast.literal_eval(
+        byte_string.replace('\\/', "/")
         .encode('utf-8').decode('unicode-escape')
         .replace("\n", "")
         .replace('null', '"null"')

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,9 @@ version = "3.12.2"
 
 if sys.argv[1] == "release":
     if not distutils.spawn.find_executable("twine"):
-        print("Please install twine:\n\n\tpip install twine\n", file=sys.stderr)
+        print(
+            "Please install twine:\n\n\tpip install twine\n", file=sys.stderr
+        )
         sys.exit(1)
 
     commands = [
@@ -35,7 +37,9 @@ def get_long_description():
     try:
         import github2pypi
 
-        return github2pypi.replace_url(slug="wkentaro/gdown", content=long_description)
+        return github2pypi.replace_url(
+            slug="wkentaro/gdown", content=long_description
+        )
     except Exception:
         return long_description
 
@@ -44,7 +48,13 @@ setup(
     name="gdown",
     version=version,
     packages=find_packages(exclude=["github2pypi"]),
-    install_requires=["filelock", "requests[socks]", "six", "tqdm", "beautifulsoup4"],
+    install_requires=[
+        "filelock",
+        "requests[socks]",
+        "six",
+        "tqdm",
+        "beautifulsoup4",
+    ],
     description="Google Drive direct download of big files.",
     long_description=get_long_description(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     name="gdown",
     version=version,
     packages=find_packages(exclude=["github2pypi"]),
-    install_requires=["filelock", "requests[socks]", "six", "tqdm"],
+    install_requires=["filelock", "requests[socks]", "six", "tqdm", "beautifulsoup4"],
     description="Google Drive direct download of big files.",
     long_description=get_long_description(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,13 @@ setup(
     name="gdown",
     version=version,
     packages=find_packages(exclude=["github2pypi"]),
-    install_requires=["filelock", "requests[socks]", "six", "tqdm", "beautifulsoup4"],
+    install_requires=[
+        "filelock",
+        "requests[socks]",
+        "six",
+        "tqdm",
+        "beautifulsoup4"
+    ],
     description="Google Drive direct download of big files.",
     long_description=get_long_description(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         "six",
         "tqdm",
         "beautifulsoup4",
+        "pathlib2",
     ],
     description="Google Drive direct download of big files.",
     long_description=get_long_description(),

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,7 @@ version = "3.12.2"
 
 if sys.argv[1] == "release":
     if not distutils.spawn.find_executable("twine"):
-        print(
-            "Please install twine:\n\n\tpip install twine\n", file=sys.stderr
-        )
+        print("Please install twine:\n\n\tpip install twine\n", file=sys.stderr)
         sys.exit(1)
 
     commands = [
@@ -37,9 +35,7 @@ def get_long_description():
     try:
         import github2pypi
 
-        return github2pypi.replace_url(
-            slug="wkentaro/gdown", content=long_description
-        )
+        return github2pypi.replace_url(slug="wkentaro/gdown", content=long_description)
     except Exception:
         return long_description
 
@@ -48,13 +44,7 @@ setup(
     name="gdown",
     version=version,
     packages=find_packages(exclude=["github2pypi"]),
-    install_requires=[
-        "filelock",
-        "requests[socks]",
-        "six",
-        "tqdm",
-        "beautifulsoup4"
-    ],
+    install_requires=["filelock", "requests[socks]", "six", "tqdm", "beautifulsoup4"],
     description="Google Drive direct download of big files.",
     long_description=get_long_description(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This commit solves the problem of downloading entire Google Drive folders, which has been an issue for quite a while (#62, #65).

This solution uses Beautiful Soup to get the `<script>` tag that contains `window['_DRIVE_ivd']`, an array that stores the folder configuration of the files and subfolders within a Google Drive folder.

The code for folder downloads (currently) supports:

 - [X] nested folders (High priority; done)
 - [X] preserved/custom folder structure (High priority; done)
 - [X] cookie use (Medium priority, done)
 - [ ] testing and proper coverage (Medium priority)
 - [X] basic CLI (Medium priority; done)
 - [X] parameters and return codes (Low priority; done)

Here are other low priority features that may or may not be implemented in the near future:
 - interactive CLI
 - cached downloads and proxy in prefetch
 - auto-detection of file and folder IDs
 - custom domain URLs
 - proper encoding handling
 - proper handling of native Google Apps files and extensionless files



These may be added in a future update.

Fixes #62 .