### PR TITLE
Added support for .rar files in extractall function [Requires unrar or unar]

### DIFF
--- a/gdown/extractall.py
+++ b/gdown/extractall.py
@@ -1,4 +1,5 @@
 import os.path as osp
+import rarfile
 import tarfile
 import zipfile
 
@@ -25,6 +26,8 @@ def extractall(path, to=None):
         opener, mode = tarfile.open, "r:gz"
     elif path.endswith(".tar.bz2") or path.endswith(".tbz"):
         opener, mode = tarfile.open, "r:bz2"
+    elif path.endswith(".rar"):
+        opener, mode = rarfile.RarFile, "r"
     else:
         raise ValueError(
             "Could not extract '%s' as no appropriate "
@@ -32,7 +35,7 @@ def extractall(path, to=None):
         )
 
     def namelist(f):
-        if isinstance(f, zipfile.ZipFile):
+        if isinstance(f, zipfile.ZipFile) or isinstance(f, rarfile.RarFile):
             return f.namelist()
         return [m.path for m in f.members]
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     name="gdown",
     version=version,
     packages=find_packages(exclude=["github2pypi"]),
-    install_requires=["filelock", "requests[socks]", "six", "tqdm"],
+    install_requires=["filelock", "requests[socks]", "six", "tqdm", "rarfile"],
     description="Google Drive direct download of big files.",
     long_description=get_long_description(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
However it does require that `unrar` or `unar` to be present in the PATH variable, and the package i am using (`rarfile`) doesn't support python <3.6 because it contains f-strings.
