### PR TITLE
Add control over the verification of the server's TLS certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pip install gdown
 ```bash
 $ gdown --help
 usage: gdown [-h] [-V] [-O OUTPUT] [-q] [--id] [--proxy PROXY] [--speed SPEED]
-             [--no-cookies] [--no-verify]
+             [--no-cookies] [--no-check-certificate]
              url_or_id
 ...
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pip install gdown
 ```bash
 $ gdown --help
 usage: gdown [-h] [-V] [-O OUTPUT] [-q] [--id] [--proxy PROXY] [--speed SPEED]
-             [--no-cookies]
+             [--no-cookies] [--no-verify]
              url_or_id
 ...
 
@@ -78,7 +78,7 @@ import gdown
 
 url = 'https://drive.google.com/uc?id=0B9P1L--7Wd2vNm9zMTJWOGxobkU'
 output = '20150428_collected_images.tgz'
-gdown.download(url, output, quiet=False)
+gdown.download(url, output, quiet=False, verify=True)
 
 md5 = 'fa837a88f0c40c513d975104edf3da17'
 gdown.cached_download(url, output, md5=md5, postprocess=gdown.extractall)

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -87,7 +87,7 @@ def main():
         action="store_true",
         help="don't verify the server's TLS certificate",
     )
-    
+
     args = parser.parse_args()
 
     if args.output == "-":

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -83,9 +83,9 @@ def main():
         help="don't use cookies in ~/.cache/gdown/cookies.json",
     )
     parser.add_argument(
-        "--no-verify",
+        "--no-check-certificate",
         action="store_true",
-        help="don't verify the server's TLS certificate",
+        help="don't check the server's TLS certificate",
     )
 
     args = parser.parse_args()
@@ -108,7 +108,7 @@ def main():
         proxy=args.proxy,
         speed=args.speed,
         use_cookies=not args.no_cookies,
-        verify=not args.no_verify,
+        verify=not args.no_check_certificate,
     )
 
 

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -82,7 +82,12 @@ def main():
         action="store_true",
         help="don't use cookies in ~/.cache/gdown/cookies.json",
     )
-
+    parser.add_argument(
+        "--no-verify",
+        action="store_true",
+        help="don't verify the server's TLS certificate",
+    )
+    
     args = parser.parse_args()
 
     if args.output == "-":
@@ -103,6 +108,7 @@ def main():
         proxy=args.proxy,
         speed=args.speed,
         use_cookies=not args.no_cookies,
+        verify=not args.no_verify,
     )
 
 

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -60,7 +60,8 @@ def get_url_from_gdrive_confirmation(contents):
 
 
 def download(
-    url, output=None, quiet=False, proxy=None, speed=None, use_cookies=True
+    url, output=None, quiet=False, proxy=None, speed=None, use_cookies=True,
+    verify=True,
 ):
     """Download file from URL.
 
@@ -78,6 +79,10 @@ def download(
         Download byte size per second (e.g., 256KB/s = 256 * 1024).
     use_cookies: bool
         Flag to use cookies. Default is True.
+    verify: bool or string
+        Either a bool, in which case it controls whether the server’s TLS
+        certificate is verified, or a string, in which case it must be a path
+        to a CA bundle to use. Default is True.
 
     Returns
     -------
@@ -107,7 +112,7 @@ def download(
     while True:
 
         try:
-            res = sess.get(url, stream=True)
+            res = sess.get(url, stream=True, verify=verify)
         except requests.exceptions.ProxyError as e:
             print("An error has occurred using proxy:", proxy, file=sys.stderr)
             print(e, file=sys.stderr)

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -60,7 +60,12 @@ def get_url_from_gdrive_confirmation(contents):
 
 
 def download(
-    url, output=None, quiet=False, proxy=None, speed=None, use_cookies=True,
+    url,
+    output=None,
+    quiet=False,
+    proxy=None,
+    speed=None,
+    use_cookies=True,
     verify=True,
 ):
     """Download file from URL.


### PR DESCRIPTION
Solves #86 by adding a `verify` parameter to the `download` method, either a boolean to control whether the server's TLS certificate should be verified, or a string with a path to a CA bundle to use for verification purposes. This parameter defaults to `True`, but setting it to `False` is so available and useful during local development, testing, or with specific servers with troublesome certificate configurations. This also adds a `--no-verify` option to the gdown CLI.
