### PR TITLE
Set requests version to 2.12.0 or higher.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     name="gdown",
     version=version,
     packages=find_packages(exclude=["github2pypi"]),
-    install_requires=["filelock", "requests[socks]", "six", "tqdm"],
+    install_requires=["filelock", "requests[socks]>=2.12.0", "six", "tqdm"],
     description="Google Drive direct download of big files.",
     long_description=get_long_description(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
After I pip install `gdown` with `requests` version 2.2.0, `gdown` command outputs an error.
I think this is because requests[socks] extras_require is not added in old version of `requests`.

In this pull request, I add `requests[socks]>=2.12.0` to setup.py.
From `requests` 2.12.0, correct requests[socks] extras_require is added.
https://github.com/psf/requests/commit/dedf9064c6fae669995d0dc04081f93845ca9c42

The following is a log of the problem I was experiencing.
1. check if requests==2.2.1
```
user@61195c8ade5f:~/gdown$ pip show requests                                                         
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python 
as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. Mor
e details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/rel
ease-process/#python-2-support pip 21.0 will remove support for this functionality.                  
Name: requests                                                                                       
Version: 2.2.1                                                                                       
Summary: Python HTTP for Humans.                                                                     
Home-page: http://python-requests.org                                                                
Author: Kenneth Reitz                                                                                
Author-email: me@kennethreitz.com                                                                    
License: Copyright 2014 Kenneth Reitz                                                                
Location: /usr/lib/python2.7/dist-packages                                                           
Requires:                                                                                            
Required-by: gdown
```

2. pip install gdown
```
user@61195c8ade5f:~/gdown$ pip install gdown
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python 
as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. Mor
e details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/rel
ease-process/#python-2-support pip 21.0 will remove support for this functionality.
Defaulting to user installation because normal site-packages is not writeable
Requirement already satisfied: gdown in /usr/local/lib/python2.7/dist-packages (3.12.2)
Requirement already satisfied: filelock in /home/user/.local/lib/python2.7/site-packages (from gdown)
 (3.0.12)
Requirement already satisfied: requests[socks] in /usr/lib/python2.7/dist-packages (from gdown) (2.2.
1)
  WARNING: requests 2.2.1 does not provide the extra 'socks'
Requirement already satisfied: six in /usr/local/lib/python2.7/dist-packages (from gdown) (1.15.0)
Requirement already satisfied: tqdm in /home/user/.local/lib/python2.7/site-packages (from gdown) (4.
56.0)
```

3. gdown command outputs error
```
user@61195c8ade5f:~/gdown$ gdown
Traceback (most recent call last):
  File "/usr/local/bin/gdown", line 5, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2749, in <module>
    working_set = WorkingSet._build_master()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 444, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 725, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 633, in resolve
    requirements.extend(dist.requires(req.extras)[::-1])
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2299, in requires
    "%s has no such extra feature %r" % (self, ext)
pkg_resources.UnknownExtra: requests 2.2.1 has no such extra feature 'socks'
```