### PR TITLE
Added fake user agent

### DIFF
--- a/gdown/download.py
+++ b/gdown/download.py
@@ -104,10 +104,12 @@ def download(
 
     file_id, is_download_link = parse_url(url)
 
+    headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}
+
     while True:
 
         try:
-            res = sess.get(url, stream=True)
+            res = sess.get(url, headers=headers, stream=True)
         except requests.exceptions.ProxyError as e:
             print("An error has occurred using proxy:", proxy, file=sys.stderr)
             print(e, file=sys.stderr)

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -104,7 +104,9 @@ def download(
 
     file_id, is_download_link = parse_url(url)
 
-    headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36"  # NOQA
+    }
 
     while True:
 


### PR DESCRIPTION
I am surprised that, this is not being used here. By passing User-Agent header, Google drive assumes the request is coming from a browser, and it avoids following errors.



 	Access denied with the following error:

		Too many users have viewed or downloaded this file recently. Please
		try accessing the file again later. If the file you are trying to
		access is particularly large or is shared with many people, it may
		take up to 24 hours to be able to view or download the file. If you
		still can't access a file after 24 hours, contact your domain
		administrator.
	You may still be able to access the file from the browser:
