### PR TITLE
Add URL normalizer to download the right file on google drive, not the HTML page

### DIFF
--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -8,6 +8,7 @@ import pkg_resources
 import six
 
 from .download import download
+from .parse_url import google_drive_url_normalizer
 
 distribution = pkg_resources.get_distribution("gdown")
 
@@ -91,10 +92,8 @@ def main():
         else:
             args.output = sys.stdout
 
-    if args.id:
-        url = "https://drive.google.com/uc?id={id}".format(id=args.url_or_id)
-    else:
-        url = args.url_or_id
+    url = google_drive_url_normalizer(args.url_or_id)
+
 
     filename = download(
         url=url,

--- a/gdown/parse_url.py
+++ b/gdown/parse_url.py
@@ -33,3 +33,21 @@ def parse_url(url, warning=True):
         )
 
     return file_id, is_download_link
+
+
+def google_drive_url_normalizer(url_or_id):
+    """Normalize and handle URLs or IDs especially for Google Drive links.
+
+    url_or_id: Downloadable URL or ID of a Google Drive link.
+    """
+    if ('drive.google.com' in url_or_id):
+        arr = url_or_id.split("/")[-3:]
+        for gdid in arr:
+            if len(gdid) == 33:
+                break
+        return 'https://drive.google.com/uc?id=' + gdid
+        
+    elif len(url_or_id) == 33:
+        return "https://drive.google.com/uc?id={id}".format(id=url_or_id)
+    else:
+        return url_or_id

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = "3.13.0"
+version = "3.13.1"
 
 
 if sys.argv[1] == "release":


### PR DESCRIPTION
Hello,
I had a problem with gdown, the **--id** works fine but when you directly use google drive standard URLs, which does not contain **uc?id=**, gdown automatically download the HTML page but the user's goal is something else, at least no one is trying to download a google drive page.
So I just handle it for google drive links and it still can download the content of websites like **wget** like before.
every type of link that includes **drive.google.com** and that **33 characters ID** is supported in this version.

Thanks for your great tool.