### PR TITLE
Add control over the verification of the server's TLS certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pip install gdown
 ```bash
 $ gdown --help
 usage: gdown [-h] [-V] [-O OUTPUT] [-q] [--id] [--proxy PROXY] [--speed SPEED]
-             [--no-cookies]
+             [--no-cookies] [--no-check-certificate]
              url_or_id
 ...
 

--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -49,13 +49,7 @@ def assert_md5sum(filename, md5, quiet=False, blocksize=None):
 
 
 def cached_download(
-    url,
-    path=None,
-    md5=None,
-    quiet=False,
-    postprocess=None,
-    proxy=None,
-    speed=None,
+    url, path=None, md5=None, quiet=False, postprocess=None, **kwargs
 ):
     """Cached download from URL.
 
@@ -71,10 +65,8 @@ def cached_download(
         Suppress terminal output. Default is False.
     postprocess: callable
         Function called with filename as postprocess.
-    proxy: str
-        Proxy.
-    speed: float
-        Download byte size per second (e.g., 256KB/s = 256 * 1024).
+    kwargs: dict
+        Keyword arguments to be passed to `download`.
 
     Returns
     -------
@@ -120,7 +112,7 @@ def cached_download(
                 msg = "{}...".format(msg)
             print(msg, file=sys.stderr)
 
-        download(url, temp_path, quiet=quiet, proxy=proxy, speed=speed)
+        download(url, temp_path, quiet=quiet, **kwargs)
         with filelock.FileLock(lock_path):
             shutil.move(temp_path, path)
     except Exception:

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -82,6 +82,11 @@ def main():
         action="store_true",
         help="don't use cookies in ~/.cache/gdown/cookies.json",
     )
+    parser.add_argument(
+        "--no-check-certificate",
+        action="store_true",
+        help="don't check the server's TLS certificate",
+    )
 
     args = parser.parse_args()
 
@@ -103,6 +108,7 @@ def main():
         proxy=args.proxy,
         speed=args.speed,
         use_cookies=not args.no_cookies,
+        verify=not args.no_check_certificate,
     )
 
     if filename is None:

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -67,7 +67,13 @@ def get_url_from_gdrive_confirmation(contents):
 
 
 def download(
-    url, output=None, quiet=False, proxy=None, speed=None, use_cookies=True
+    url,
+    output=None,
+    quiet=False,
+    proxy=None,
+    speed=None,
+    use_cookies=True,
+    verify=True,
 ):
     """Download file from URL.
 
@@ -85,6 +91,10 @@ def download(
         Download byte size per second (e.g., 256KB/s = 256 * 1024).
     use_cookies: bool
         Flag to use cookies. Default is True.
+    verify: bool or string
+        Either a bool, in which case it controls whether the server’s TLS
+        certificate is verified, or a string, in which case it must be a path
+        to a CA bundle to use. Default is True.
 
     Returns
     -------
@@ -117,7 +127,7 @@ def download(
 
     while True:
         try:
-            res = sess.get(url, headers=headers, stream=True)
+            res = sess.get(url, headers=headers, stream=True, verify=verify)
         except requests.exceptions.ProxyError as e:
             print("An error has occurred using proxy:", proxy, file=sys.stderr)
             print(e, file=sys.stderr)


### PR DESCRIPTION
Moved from https://github.com/wkentaro/gdown/pull/87
Close https://github.com/wkentaro/gdown/issues/86

This commit adds an option, either a boolean to control whether it
verifies the server's TLS certificate, or a string with a path to
a CA bundle to use. This option defaults to True, but setting it
to False is useful during local development and testing.