### PR TITLE
[cli] treat url as an id if it doesn't seem like a url

### DIFF
--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -122,11 +122,12 @@ def main():
         else:
             args.output = sys.stdout
 
-    if args.id:
+    url_or_id = args.url_or_id.lstrip()
+    if args.id or not re.match("^https?\:", url_or_id):
         url = None
-        id = args.url_or_id
+        id = url_or_id
     else:
-        url = args.url_or_id
+        url = url_or_id
         id = None
 
     if args.folder:


### PR DESCRIPTION
improvement to gdown ergonomics, since you no longer have to know about `--id`, so you can just do
```
$ gdown "https://drive.google.com/uc?id=12345678"
```
or 
```
$ gdown 12345678
```
