### PR TITLE
Fix download_folder

### DIFF
--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -117,7 +117,7 @@ def parse_google_drive_file(folder, content, use_cookies=True):
 
     gdrive_file = GoogleDriveFile(
         id=folder.split("/")[-1],
-        name=" - ".join(folder_soup.title.contents[0].split(" - ")[:-1]),
+        name=folder_soup.title.contents[0].rsplit(" – ",1)[0],
         type=folder_type,
     )
 
@@ -200,6 +200,7 @@ def download_and_parse_google_drive_link(
             folders_url + child_id,
             use_cookies=use_cookies,
             quiet=quiet,
+            remaining_ok=remaining_ok,
         )
         if not return_code:
             return return_code, None


### PR DESCRIPTION
Hello, I noticed two small problems that occur when using the download_folder function.

## 1. pass remaining_ok to internal recursion

When using remaining_ok, it's not passed to download_and_parse_google_drive_link when parsing folders within folders.

## 2. correctly parse the folder name

Google uses "–" instead of "-", which is the cause of the current name folder finding to always return an empty name for the folder.