### PR TITLE
Fix unicode error in gdown.download_folder

### DIFF
--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 from __future__ import print_function
 
 from itertools import islice
@@ -351,7 +353,7 @@ def download_folder(
 
         filename = download(
             files_url + file_id,
-            output=str(file_path),
+            output=file_path,
             quiet=quiet,
             proxy=proxy,
             speed=speed,


### PR DESCRIPTION
Close https://github.com/wkentaro/gdown/issues/197

```
% gdown --folder 'https://drive.google.com/drive/folders/1fQrF9TapZVWrxiKmasMUbIMfPu-Kvv2J?usp=sharing'
Retrieving folder list
Processing file 1i_CrVrClbr_YNeiI50WGK8ccgpyiLg1J áéíóúñ.txt
Retrieving folder list completed
Building directory structure
Building directory structure completed
Downloading...
From: https://drive.google.com/uc?id=1i_CrVrClbr_YNeiI50WGK8ccgpyiLg1J
To: /Users/wkentaro/Documents/gdown/áéíóúñ/áéíóúñ.txt
0.00B [00:00, ?B/s]
Download completed
```