### PR TITLE
Unify Dash Types

### DIFF
--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -117,12 +117,10 @@ def parse_google_drive_file(folder, content, use_cookies=True):
 
     folder_contents = [] if folder_arr[0] is None else folder_arr[0]
 
-    seps = [" - ", " – "]  # unicode dash and endash
-    for sep in seps:
-        splitted = folder_soup.title.contents[0].split(sep)
-        if len(splitted) >= 2:
-            name = sep.join(splitted[:-1])
-            break
+    separator = " - "
+    splitted = folder_soup.title.contents[0].replace(" – ", separator).split(separator) # unify dash types
+    if len(splitted) >= 2:
+        name = separator.join(splitted[:-1])
 
     gdrive_file = GoogleDriveFile(
         id=folder.split("/")[-1],


### PR DESCRIPTION
Hi, this PR aims to fix a bug where there are 2 types of dashes in the title of the page.

Example (one dash is of one type separator, the other is another):
Avenged Sevenfold - A Little Piece of Heaven - Google Drive

When the split happens, it looks at the first one through pure coincidence:
`name = "Avenged Sevenfold"`

What we really want is:
`name = "Avenged Sevenfold - A Little Piece of Heaven"`

Let me know if this fix works.