### PR TITLE
Fix non-latin alphabet filename parsing

### DIFF
--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -117,10 +117,10 @@ def parse_google_drive_file(folder, content, use_cookies=True):
     folder_arr = json.loads(decoded)
 
     folder_contents = [] if folder_arr[0] is None else folder_arr[0]
+
     seps = [" - ", " – "]  # unicode dash and endash
     for sep in seps:
         splitted = unicodedata.normalize("NFKD", folder_soup.title.contents[0]).split(sep)
-        print(f"SPLITTED: {splitted}")
         if len(splitted) >= 2:
             name = sep.join(splitted[:-1])
             break

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -9,6 +9,7 @@ import os.path as osp
 import re
 import sys
 import textwrap
+import unicodedata
 
 from bs4 import BeautifulSoup
 import requests
@@ -116,10 +117,10 @@ def parse_google_drive_file(folder, content, use_cookies=True):
     folder_arr = json.loads(decoded)
 
     folder_contents = [] if folder_arr[0] is None else folder_arr[0]
-
     seps = [" - ", " – "]  # unicode dash and endash
     for sep in seps:
-        splitted = folder_soup.title.contents[0].split(sep)
+        splitted = unicodedata.normalize("NFKD", folder_soup.title.contents[0]).split(sep)
+        print(f"SPLITTED: {splitted}")
         if len(splitted) >= 2:
             name = sep.join(splitted[:-1])
             break


### PR DESCRIPTION
Fix for #205. Normalizing replaces strange space characters with common ones, letting the upcoming splitting function properly again.