### PR TITLE
Add the support for the external user cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ $ gdown --fuzzy "https://docs.google.com/presentation/d/15umvZKlsJ3094HNg5S4vJsI
 $ # a folder
 $ gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl -O /tmp/folder --folder
 
+$ # using a cookie files
+$ # my_cookies.txt
+$ # {
+$ # 		"__Secure-1PAPISID": "XXXXXXXX",
+$ # 		"__Secure-1PSID": "XXXXXXX",
+$ # 		"SSID": "XXXXXXXXX"
+$ # }
+$ gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl --cookies=my_cookies.txt
+
 $ # as an alternative to curl/wget
 $ gdown https://httpbin.org/ip -O ip.json
 $ cat ip.json

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $ # my_cookies.txt
 $ # {
 $ # 		"__Secure-1PAPISID": "XXXXXXXX",
 $ # 		"__Secure-1PSID": "XXXXXXX",
-$ #      ...
+$ # 		...
 $ # 		"SSID": "XXXXXXXXX"
 $ # }
 $ gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl --cookies=my_cookies.txt

--- a/README.md
+++ b/README.md
@@ -74,11 +74,12 @@ $ gdown --fuzzy "https://docs.google.com/presentation/d/15umvZKlsJ3094HNg5S4vJsI
 $ # a folder
 $ gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl -O /tmp/folder --folder
 
-$ # using a cookie files
+$ # using the cookis from a file
 $ # my_cookies.txt
 $ # {
 $ # 		"__Secure-1PAPISID": "XXXXXXXX",
 $ # 		"__Secure-1PSID": "XXXXXXX",
+$ #      ...
 $ # 		"SSID": "XXXXXXXXX"
 $ # }
 $ gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl --cookies=my_cookies.txt

--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ url = "https://drive.google.com/uc?id=1l_5RK28JRL19wpT22B-DY9We3TVXnnQQ"
 output = "fcn8s_from_caffe.npz"
 gdown.download(url, output, quiet=False)
 
+
+# downloa file with user cookies
+cookies = {
+ 	"__Secure-1PAPISID": "XXXXXXXX",
+ 	"__Secure-1PSID": "XXXXXXX",
+ 	...
+ 	"SSID": "XXXXXXXXX"
+}
+id = "15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl"
+gdown.download_folder(id=id, cookies = cookies)
+
 # same as the above, but with the file ID
 id = "0B9P1L--7Wd2vNm9zMTJWOGxobkU"
 gdown.download(id=id, output=output, quiet=False)
@@ -127,6 +138,9 @@ gdown.download_folder(url, quiet=True, use_cookies=False)
 id = "15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl"
 gdown.download_folder(id=id, quiet=True, use_cookies=False)
 ```
+
+
+
 
 
 ## License

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -96,6 +96,12 @@ def main():
         help="don't check the server's TLS certificate",
     )
     parser.add_argument(
+        "--cookies",
+        action="store",
+        const=None,
+        help="read the cookies from file",
+    )
+    parser.add_argument(
         "--continue",
         "-c",
         dest="continue_",
@@ -149,6 +155,7 @@ def main():
             proxy=args.proxy,
             speed=args.speed,
             use_cookies=not args.no_cookies,
+            cookies=args.cookies,
             remaining_ok=args.remaining_ok,
         )
         success = filenames is not None
@@ -160,6 +167,7 @@ def main():
             proxy=args.proxy,
             speed=args.speed,
             use_cookies=not args.no_cookies,
+            cookies=args.cookies,
             verify=not args.no_check_certificate,
             id=id,
             fuzzy=args.fuzzy,


### PR DESCRIPTION
The Google would probiden the anonymous download of large size file by too many user in a short periodic of time
The error is given by

> Too many users have viewed or downloaded this file recently. Please try accessing the file again later. If the file you are trying to access is particularly large or is shared with many people, it may take up to 24 hours to be able to view or download the file. If you still can't access a file after 24 hours, contact your domain administrator.

So, a user cookies file (obtained from the browser) is necessary, like the following file,
```
my_cookies.txt
{
 	"__Secure-1PAPISID": "XXXXXXXX",
	"__Secure-1PSID": "XXXXXXX", 		
	...
 	"SSID": "XXXXXXXXX"
 }
gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl --cookies=my_cookies.txt
```

