### PR TITLE
Add exclusion feature by folder name, file name and file type for folder links

### DIFF
--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -52,7 +52,25 @@ def main():
         action=_ShowVersionAction,
         help="display version",
         nargs=0,
-    )
+    )    
+    parser.add_argument(
+        "-exclude_folder",
+        type=str,
+        default='[]',
+        help="will not download the content of the specified folder, usage : -exclude_folder='[folder1, folder2, folder3 ...etc ]', --folder must be specified",
+    )    
+    parser.add_argument(
+        "-exclude_file",
+        type=str,
+        default='[]',
+        help="will not download the specified file usage : -exclude_file='[file1, file2, file3 ...etc ]', --folder must be specified",
+    )    
+    parser.add_argument(
+        "-exclude_filetype",
+        type=str,
+        default='[]',
+        help="will not download the specified file type, usage : -exclude_filetype='[*.type1, *.type2, *.type3 ...etc ]', --folder must be specified",
+    )   
     parser.add_argument(
         "url_or_id", help="url or file/folder id (with --id) to download from"
     )
@@ -144,6 +162,9 @@ def main():
             speed=args.speed,
             use_cookies=not args.no_cookies,
             remaining_ok=args.remaining_ok,
+            exclude_folder=args.exclude_folder,
+            exclude_file=args.exclude_file,
+            exclude_filetype=args.exclude_filetype,            
         )
         success = filenames is not None
     else:

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -55,21 +55,21 @@ def main():
     )    
     parser.add_argument(
         "-exclude_folder",
-        type=str,
+        nargs='+',
         default='[]',
-        help="will not download the content of the specified folder, usage : -exclude_folder='[folder1, folder2, folder3 ...etc ]', --folder must be specified",
+        help="will not download the content of the specified folder, usage : -exclude_folder folder1 folder2 folder3 ...etc , --folder must be specified",
     )    
     parser.add_argument(
         "-exclude_file",
-        type=str,
+        nargs='+',
         default='[]',
-        help="will not download the specified file usage : -exclude_file='[file1, file2, file3 ...etc ]', --folder must be specified",
+        help="will not download the specified file, usage : -exclude_file file1 file2 file3 ...etc , --folder must be specified",
     )    
     parser.add_argument(
         "-exclude_filetype",
-        type=str,
+        nargs='+',
         default='[]',
-        help="will not download the specified file type, usage : -exclude_filetype='[*.type1, *.type2, *.type3 ...etc ]', --folder must be specified",
+        help="will not download the specified file type, usage : -exclude_filetype .type1, .type2, .type3 ...etc, --folder must be specified",
     )   
     parser.add_argument(
         "url_or_id", help="url or file/folder id (with --id) to download from"

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -56,19 +56,19 @@ def main():
     parser.add_argument(
         "-exclude_folder",
         nargs='+',
-        default='[]',
+        default=[],
         help="will not download the content of the specified folder, usage : -exclude_folder folder1 folder2 folder3 ...etc , --folder must be specified",
     )    
     parser.add_argument(
         "-exclude_file",
         nargs='+',
-        default='[]',
+        default=[],
         help="will not download the specified file, usage : -exclude_file file1 file2 file3 ...etc , --folder must be specified",
     )    
     parser.add_argument(
         "-exclude_filetype",
         nargs='+',
-        default='[]',
+        default=[],
         help="will not download the specified file type, usage : -exclude_filetype .type1, .type2, .type3 ...etc, --folder must be specified",
     )   
     parser.add_argument(

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -139,6 +139,9 @@ def parse_google_drive_file(folder, content, use_cookies=True):
 
 def download_and_parse_google_drive_link(
     folder,
+    exclude_folder,
+    exclude_file,
+    exclude_filetype,    
     quiet=False,
     use_cookies=True,
     remaining_ok=False,
@@ -187,13 +190,14 @@ def download_and_parse_google_drive_link(
                     child_id,
                     child_name,
                 )
-            gdrive_file.children.append(
-                GoogleDriveFile(
-                    id=child_id,
-                    name=child_name,
-                    type=child_type,
+            if ("*"+osp.splitext(child_name)[1] not in exclude_filetype) and (child_name not in exclude_file) and (gdrive_file.name not in exclude_folder):    
+                gdrive_file.children.append(
+                    GoogleDriveFile(
+                        id=child_id,
+                        name=child_name,
+                        type=child_type,
+                    )
                 )
-            )
             if not return_code:
                 return return_code, None
             continue
@@ -206,6 +210,9 @@ def download_and_parse_google_drive_link(
             )
         return_code, child = download_and_parse_google_drive_link(
             folders_url + child_id,
+            exclude_folder,
+            exclude_file,
+            exclude_filetype,            
             use_cookies=use_cookies,
             quiet=quiet,
             remaining_ok=remaining_ok,
@@ -262,6 +269,9 @@ def get_directory_structure(gdrive_file, previous_path):
 
 
 def download_folder(
+    exclude_folder,
+    exclude_file,
+    exclude_filetype,    
     url=None,
     id=None,
     output=None,
@@ -269,7 +279,7 @@ def download_folder(
     proxy=None,
     speed=None,
     use_cookies=True,
-    remaining_ok=False,
+    remaining_ok=False,  
 ):
     """Downloads entire folder from URL.
 
@@ -318,6 +328,9 @@ def download_folder(
             quiet=quiet,
             use_cookies=use_cookies,
             remaining_ok=remaining_ok,
+            exclude_folder=exclude_folder,
+            exclude_file=exclude_file,
+            exclude_filetype=exclude_filetype,            
         )
     except RuntimeError as e:
         print("Failed to retrieve folder contents:", file=sys.stderr)

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -190,7 +190,7 @@ def download_and_parse_google_drive_link(
                     child_id,
                     child_name,
                 )
-            if ("*"+osp.splitext(child_name)[1] not in exclude_filetype) and (child_name not in exclude_file) and (gdrive_file.name not in exclude_folder):    
+            if (osp.splitext(child_name)[1] not in exclude_filetype) and (child_name not in exclude_file) and (gdrive_file.name not in exclude_folder):    
                 gdrive_file.children.append(
                     GoogleDriveFile(
                         id=child_id,


### PR DESCRIPTION
"-exclude_folder" : will not download the content of the specified folder, usage : -exclude_folder folder1 folder2 folder3 ...etc 

"-exclude_file" :will not download the specified file, usage : -exclude_file file1 file2 file3 ...etc

"-exclude_filetype" :will not download the specified file type, usage : -exclude_filetype .type1, .type2, .type3 ...etc

I set the prefix to "-" instead of "--" to not confuse them with the main arguments, as these require --folder.