### PR TITLE
Adapt gdown to be used as python library

### DIFF
--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -88,11 +88,8 @@ def cached_download(
             print("File exists: {}".format(path))
         return path
     elif osp.exists(path) and md5:
-        try:
-            assert_md5sum(path, md5, quiet=quiet)
-            return path
-        except AssertionError as e:
-            print(e, file=sys.stderr)
+        assert_md5sum(path, md5, quiet=quiet)
+        return path
 
     # download
     lock_path = osp.join(cache_root, "_dl_lock")
@@ -110,7 +107,7 @@ def cached_download(
                 msg = "{}: {}".format(msg, path)
             else:
                 msg = "{}...".format(msg)
-            print(msg, file=sys.stderr)
+            print(msg)
 
         download(url, temp_path, quiet=quiet, **kwargs)
         with filelock.FileLock(lock_path):

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -134,33 +134,38 @@ def main():
             url = None
             id = args.url_or_id
 
-    if args.folder:
-        filenames = download_folder(
-            url=url,
-            id=id,
-            output=args.output,
-            quiet=args.quiet,
-            proxy=args.proxy,
-            speed=args.speed,
-            use_cookies=not args.no_cookies,
-            verify=not args.no_check_certificate,
-            remaining_ok=args.remaining_ok,
-        )
-        success = filenames is not None
-    else:
-        filename = download(
-            url=url,
-            output=args.output,
-            quiet=args.quiet,
-            proxy=args.proxy,
-            speed=args.speed,
-            use_cookies=not args.no_cookies,
-            verify=not args.no_check_certificate,
-            id=id,
-            fuzzy=args.fuzzy,
-            resume=args.continue_,
-        )
-        success = filename is not None
+
+    try:
+        if args.folder:
+            filenames = download_folder(
+                url=url,
+                id=id,
+                output=args.output,
+                quiet=args.quiet,
+                proxy=args.proxy,
+                speed=args.speed,
+                use_cookies=not args.no_cookies,
+                verify=not args.no_check_certificate,
+                remaining_ok=args.remaining_ok,
+            )
+            success = filenames is not None
+        else:
+            filename = download(
+                url=url,
+                output=args.output,
+                quiet=args.quiet,
+                proxy=args.proxy,
+                speed=args.speed,
+                use_cookies=not args.no_cookies,
+                verify=not args.no_check_certificate,
+                id=id,
+                fuzzy=args.fuzzy,
+                resume=args.continue_,
+            )
+            success = filename is not None
+    except Exception as e:
+        print(e, file=sys.stderr)
+        success = False
 
     if not success:
         sys.exit(1)


### PR DESCRIPTION
Suppressing python exception makes it hard to use from python, instead exceptions can be printed only on cli (otherwise simply raised).
This PR also allows for custom progress callbacks (which defaults to old behaviour).