### PR TITLE
Fix typo: uriginal -> original

### DIFF
--- a/gdown/download.py
+++ b/gdown/download.py
@@ -298,7 +298,7 @@ def download(
         if resume:
             print("Resume:", tmp_file, file=sys.stderr)
         if url_origin != url:
-            print("From (uriginal):", url_origin, file=sys.stderr)
+            print("From (original):", url_origin, file=sys.stderr)
             print("From (redirected):", url, file=sys.stderr)
         else:
             print("From:", url, file=sys.stderr)


### PR DESCRIPTION
There was a small typo in the prompt that is shown before downloading a file in `--fuzzy` mode.