### PR TITLE
feat: ✨ pass down resume to download_folder

### DIFF
--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -203,6 +203,7 @@ def download_folder(
     use_cookies=True,
     remaining_ok=False,
     verify=True,
+    resume=False
 ):
     """Downloads entire folder from URL.
 
@@ -290,6 +291,7 @@ def download_folder(
             speed=speed,
             use_cookies=use_cookies,
             verify=verify,
+            resume=resume,
         )
 
         if filename is None:


### PR DESCRIPTION
Doesn't change the default behaviour but allow for resumable files inside a folder