### PR TITLE
Added support for resource keys

### DIFF
--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -22,10 +22,11 @@ MAX_NUMBER_FILES = 50
 class _GoogleDriveFile(object):
     TYPE_FOLDER = "application/vnd.google-apps.folder"
 
-    def __init__(self, id, name, type, children=None):
+    def __init__(self, id, name, type, resource_key=None, children=None):
         self.id = id
         self.name = name
         self.type = type
+        self.resource_key = resource_key
         self.children = children if children is not None else []
 
     def is_folder(self):
@@ -91,7 +92,7 @@ def _parse_google_drive_file(url, content):
     )
 
     id_name_type_iter = [
-        (e[0], e[2].encode("raw_unicode_escape").decode("utf-8"), e[3])
+        (e[0], e[2].encode("raw_unicode_escape").decode("utf-8"), e[3], e[139])
         for e in folder_contents
     ]
 
@@ -125,7 +126,7 @@ def _download_and_parse_google_drive_link(
         content=res.text,
     )
 
-    for child_id, child_name, child_type in id_name_type_iter:
+    for child_id, child_name, child_type, child_resource_key in id_name_type_iter:
         if child_type != _GoogleDriveFile.TYPE_FOLDER:
             if not quiet:
                 print(
@@ -138,6 +139,7 @@ def _download_and_parse_google_drive_link(
                     id=child_id,
                     name=child_name,
                     type=child_type,
+                    resource_key=child_resource_key
                 )
             )
             if not return_code:
@@ -150,9 +152,10 @@ def _download_and_parse_google_drive_link(
                 child_id,
                 child_name,
             )
+        url_suffix = f"?resourcekey={child_resource_key}" if child_resource_key else ""
         return_code, child = _download_and_parse_google_drive_link(
             sess=sess,
-            url="https://drive.google.com/drive/folders/" + child_id,
+            url=f"https://drive.google.com/drive/folders/{child_id}" + url_suffix,
             quiet=quiet,
             remaining_ok=remaining_ok,
         )
@@ -180,7 +183,7 @@ def _get_directory_structure(gdrive_file, previous_path):
         file.name = file.name.replace(osp.sep, "_")
         if file.is_folder():
             directory_structure.append(
-                (None, osp.join(previous_path, file.name))
+                (None, osp.join(previous_path, file.name), file.resource_key)
             )
             for i in _get_directory_structure(
                 file, osp.join(previous_path, file.name)
@@ -188,7 +191,7 @@ def _get_directory_structure(gdrive_file, previous_path):
                 directory_structure.append(i)
         elif not file.children:
             directory_structure.append(
-                (file.id, osp.join(previous_path, file.name))
+                (file.id, osp.join(previous_path, file.name), file.resource_key)
             )
     return directory_structure
 
@@ -276,14 +279,15 @@ def download_folder(
     if not quiet:
         print("Building directory structure completed")
     filenames = []
-    for file_id, file_path in directory_structure:
+    for file_id, file_path, file_resource_key in directory_structure:
         if file_id is None:  # folder
             if not osp.exists(file_path):
                 os.makedirs(file_path)
             continue
 
+        url_suffix = f"&resourcekey={file_resource_key}" if file_resource_key else ""
         filename = download(
-            url="https://drive.google.com/uc?id=" + file_id,
+            url=f"https://drive.google.com/uc?id={file_id}" + url_suffix,
             output=file_path,
             quiet=quiet,
             proxy=proxy,


### PR DESCRIPTION
Some folders and files require resource keys to access. When gdown parses the files in a folder, these resource keys *are* returned, but currently they are not stored for later URL construction, yielding an error when attempting to download the files. This patches this behavior, allowing the download of folders, and the files within, which require resource keys.