### PR TITLE
Feature: allow folders to be continued more usefully

### DIFF
--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -106,7 +106,11 @@ def main():
         "-c",
         dest="continue_",
         action="store_true",
-        help="resume getting a partially-downloaded file",
+        help=(
+            "resume getting partially-downloaded files "
+            "from their download tempfile, "
+            "and skip fully transferred files"
+        ),
     )
     parser.add_argument(
         "--folder",

--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -58,7 +58,14 @@ def main():
     parser.add_argument(
         "url_or_id", help="url or file/folder id (with --id) to download from"
     )
-    parser.add_argument("-O", "--output", help="output file name / path")
+    parser.add_argument(
+        "-O",
+        "--output",
+        help=(
+            f'output file name/path; end with "{os.path.sep}"'
+            "to create a new directory"
+        ),
+    )
     parser.add_argument(
         "-q",
         "--quiet",

--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -106,11 +106,8 @@ def main():
         "-c",
         dest="continue_",
         action="store_true",
-        help=(
-            "resume getting partially-downloaded files "
-            "from their download tempfile, "
-            "and skip fully transferred files"
-        ),
+        help="resume getting partially-downloaded files while "
+        "skipping fully downloaded ones",
     )
     parser.add_argument(
         "--folder",
@@ -200,7 +197,7 @@ def main():
         sys.exit(1)
     except requests.exceptions.ProxyError as e:
         print(
-            "Failed to use proxy:\n\n{}\n\n" "Please check your proxy settings.".format(
+            "Failed to use proxy:\n\n{}\n\nPlease check your proxy settings.".format(
                 indent("\n".join(textwrap.wrap(str(e))), prefix="\t")
             ),
             file=sys.stderr,

--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -106,7 +106,7 @@ def main():
         "-c",
         dest="continue_",
         action="store_true",
-        help="(file only) resume getting a partially-downloaded file",
+        help="resume getting a partially-downloaded file",
     )
     parser.add_argument(
         "--folder",
@@ -165,6 +165,7 @@ def main():
                 verify=not args.no_check_certificate,
                 remaining_ok=args.remaining_ok,
                 user_agent=args.user_agent,
+                resume=args.continue_,
             )
         else:
             download(

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -302,7 +302,7 @@ def download(
 
         existing_tmp_files = []
         for file in os.listdir(osp.dirname(output) or "."):
-            if file.startswith(osp.basename(output)):
+            if file.startswith(osp.basename(output)) and file.endswith(".part"):
                 existing_tmp_files.append(osp.join(osp.dirname(output), file))
         if resume and existing_tmp_files:
             if len(existing_tmp_files) != 1:
@@ -325,7 +325,7 @@ def download(
             # mkstemp is preferred, but does not work on Windows
             # https://github.com/wkentaro/gdown/issues/153
             tmp_file = tempfile.mktemp(
-                suffix=tempfile.template,
+                suffix=".part",
                 prefix=osp.basename(output),
                 dir=osp.dirname(output),
             )

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -19,6 +19,7 @@ from .exceptions import FileURLRetrievalError
 from .parse_url import parse_url
 
 CHUNK_SIZE = 512 * 1024  # 512KB
+TEMPFILE_SUFFIX = ".part"
 home = osp.expanduser("~")
 
 
@@ -327,12 +328,13 @@ def download(
                 )
                 return
             tmp_file = existing_tmp_files[0]
+            # Perhaps it should select the biggest one?
         else:
             resume = False
             # mkstemp is preferred, but does not work on Windows
             # https://github.com/wkentaro/gdown/issues/153
             tmp_file = tempfile.mktemp(
-                suffix=tempfile.template,
+                suffix=TEMPFILE_SUFFIX,
                 prefix=osp.basename(output),
                 dir=osp.dirname(output),
             )

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -310,7 +310,7 @@ def download(
         # Alternatively, resume mode can reuse partial tmp_files.
         existing_tmp_files = []
         for file in os.listdir(osp.dirname(output) or "."):
-            if file.startswith(osp.basename(output)):
+            if file.startswith(osp.basename(output)) and file.endswith(TEMPFILE_SUFFIX):
                 existing_tmp_files.append(osp.join(osp.dirname(output), file))
         if resume and existing_tmp_files:
             if len(existing_tmp_files) != 1:

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -242,6 +242,7 @@ def download_folder(
         Defaults to False.
     resume: bool
         Resume interrupted transfers.
+        Completed output files will be skipped.
         Partial tempfiles will be reused, if the transfer is incomplete.
         Default is False.
 
@@ -312,6 +313,16 @@ def download_folder(
                 GoogleDriveFileToDownload(id=id, path=path, local_path=local_path)
             )
         else:
+            # Shortcut existing 100% transfers here,
+            # instead of invoking download(),
+            # to avoid making unnecessary requests.
+            if resume and os.path.isfile(local_path):
+                # already downloaded this file
+                if not quiet:
+                    print(f"resume: already have {local_path}")
+                files.append(local_path)
+                continue
+
             local_path = download(
                 url="https://drive.google.com/uc?id=" + id,
                 output=local_path,

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -313,13 +313,12 @@ def download_folder(
                 GoogleDriveFileToDownload(id=id, path=path, local_path=local_path)
             )
         else:
-            # Shortcut existing 100% transfers here,
-            # instead of invoking download(),
-            # to avoid making unnecessary requests.
             if resume and os.path.isfile(local_path):
-                # already downloaded this file
                 if not quiet:
-                    print(f"resume: already have {local_path}")
+                    print(
+                        f"Skipping already downloaded file {local_path}",
+                        file=sys.stderr,
+                    )
                 files.append(local_path)
                 continue
 

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -209,6 +209,7 @@ def download_folder(
     verify=True,
     user_agent=None,
     skip_download: bool = False,
+    resume=False,
 ) -> Union[List[str], List[GoogleDriveFileToDownload], None]:
     """Downloads entire folder from URL.
 
@@ -239,6 +240,10 @@ def download_folder(
     skip_download: bool, optional
         If True, return the list of files to download without downloading them.
         Defaults to False.
+    resume: bool
+        Resume interrupted transfers.
+        Partial tempfiles will be reused, if the transfer is incomplete.
+        Default is False.
 
     Returns
     -------
@@ -315,6 +320,7 @@ def download_folder(
                 speed=speed,
                 use_cookies=use_cookies,
                 verify=verify,
+                resume=resume,
             )
             if local_path is None:
                 if not quiet:


### PR DESCRIPTION
- The `--continue` option can now be used with folders.
- When a download is being sent to a file, detect when the file to resume is complete (→ has its final name)
  - Avoids 0-byte ranged transfers (which _still_ count against the shared folder's download limit!)
  - Speeds up `--continue` (resume mode) for partially transferred folders containing lots of files.
  - Especially useful when download allowances are very limited, e.g. Tor-proxied access, or very popular folders.
- Now uses the conventional `.part` suffix for tempfiles, to make life nicer with Linux desktop thumbnailers.
- Update command line arguments to match.