### PR TITLE
Rollback to user agent from v4.6.3.

### DIFF
--- a/gdown/download.py
+++ b/gdown/download.py
@@ -54,11 +54,12 @@ def get_url_from_gdrive_confirmation(contents):
     return url
 
 
+CANNED_USER_AGENT="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36"  # NOQA
 def _get_session(proxy, use_cookies, return_cookies_file=False):
     sess = requests.session()
 
     sess.headers.update(
-        {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6)"}
+        {"User-Agent": os.getenv('GDOWN_USER_AGENT') or CANNED_USER_AGENT}
     )
 
     if proxy is not None:


### PR DESCRIPTION
The more obviously fake user-agent from 4.6.4 appears to be rejected by Google (ergo #291); the user-agent from 4.6.3 seems to work.

Also add ability to override user agent with `GDOWN_USER_AGENT` environment variable to allow users to override this for themselves without necessitating a new release.