### PR TITLE
Use MozillaCookieJar instead of json to save cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,22 @@ gdown.download_folder(id=id, quiet=True, use_cookies=False)
 ```
 
 
+## FAQ
+
+### I get 'Permission Denied' error.
+
+Have you made sure you set the file permission to 'Anyone with Link'?
+
+### I set the permission 'Anyone with Link', but still can't download.
+
+Google restricts access to a file when the download is concentrated.
+If you can still access to the file from your browser, downloading cookies file might
+help. Follow this step: 1) download cookies.txt using browser extensions like
+([Get cookies.txt LOCALLY](https://chromewebstore.google.com/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc));
+2) mv the `cookies.txt` to `~/.cache/gdown/cookies.txt`; 3) run download again.
+If you're using `gdown>=5.0.0`, it should be able to use the cookies same as your browser.
+
+
 ## License
 
 MIT

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -87,7 +87,7 @@ def main():
     parser.add_argument(
         "--no-cookies",
         action="store_true",
-        help="don't use cookies in ~/.cache/gdown/cookies.json",
+        help="don't use cookies in ~/.cache/gdown/cookies.txt",
     )
     parser.add_argument(
         "--no-check-certificate",


### PR DESCRIPTION
Close https://github.com/wkentaro/gdown/pull/287

We can use chrome extension like [Get cookies.txt LOCALLY](https://chromewebstore.google.com/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc) to export and use it.

@7x11x13 Thank you for the suggestion. I find MozzilaCookieJar format more reasonable, so let's migrate to that.