### PR TITLE
Add extra pattern to extract url from download-form returned by Google Drive for a large file

### DIFF
--- a/gdown/download.py
+++ b/gdown/download.py
@@ -59,8 +59,8 @@ def get_url_from_gdrive_confirmation(contents):
     return url
 
 
-def _get_filename_from_response(res):
-    content_disposition = urllib.parse.unquote(res.headers["Content-Disposition"])
+def _get_filename_from_response(response):
+    content_disposition = urllib.parse.unquote(response.headers["Content-Disposition"])
 
     m = re.search(r"filename\*=UTF-8''(.*)", content_disposition)
     if m:
@@ -257,7 +257,7 @@ def download(
 
     filename_from_url = None
     if gdrive_file_id and is_gdrive_download_link:
-        filename_from_url = _get_filename_from_response(res)
+        filename_from_url = _get_filename_from_response(response=res)
     if filename_from_url is None:
         filename_from_url = osp.basename(url)
 

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -59,7 +59,7 @@ def get_url_from_gdrive_confirmation(contents):
     return url
 
 
-def get_filename_from_response(res):
+def _get_filename_from_response(res):
     content_disposition = urllib.parse.unquote(res.headers["Content-Disposition"])
 
     m = re.search(r"filename\*=UTF-8''(.*)", content_disposition)
@@ -257,7 +257,7 @@ def download(
 
     filename_from_url = None
     if gdrive_file_id and is_gdrive_download_link:
-        filename_from_url = get_filename_from_response(res)
+        filename_from_url = _get_filename_from_response(res)
     if filename_from_url is None:
         filename_from_url = osp.basename(url)
 

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -255,7 +255,11 @@ def download(
             )
             raise FileURLRetrievalError(message)
 
-    filename_from_url = get_filename_from_response(res) or osp.basename(url)
+    filename_from_url = None
+    if gdrive_file_id and is_gdrive_download_link:
+        filename_from_url = get_filename_from_response(res)
+    if filename_from_url is None:
+        filename_from_url = osp.basename(url)
 
     if output is None:
         output = filename_from_url

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -67,7 +67,7 @@ def get_filename_from_response(res):
         filename = m.groups()[0]
         return filename.replace(osp.sep, "_")
 
-    m = re.search("attachment; filename=\"(.*?)\"", content_disposition)
+    m = re.search('attachment; filename="(.*?)"', content_disposition)
     if m:
         filename = m.groups()[0]
         return filename

--- a/gdown/parse_url.py
+++ b/gdown/parse_url.py
@@ -1,5 +1,5 @@
 import re
-import urllib
+import urllib.parse
 import warnings
 
 


### PR DESCRIPTION
Fixes #43. They were a few attempts to solve this, but even with the latest `gdown==5.0.1` the download still fails. The fixes so far have concentrated on cookies, but failed to realize that the original report is for large files for which GDrive asks for user confirmation since it cannot perform a virus check.

This PR addresses this part by properly parsing the confirmation form.