### PR TITLE
Replace md5 with hash in cached_download function for any hash algorithm

### DIFF
--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -30,7 +30,7 @@ def md5sum(filename, blocksize=None):
 
 def assert_md5sum(filename, md5, quiet=False, blocksize=None):
     if not (isinstance(md5, str) and len(md5) == 32):
-        raise ValueError("MD5 must be 32 chars: {}".format(md5))
+        raise ValueError(f"MD5 must be 32 chars: {md5}")
 
     md5_actual = md5sum(filename)
 
@@ -39,9 +39,7 @@ def assert_md5sum(filename, md5, quiet=False, blocksize=None):
             print(f"MD5 matches: {filename!r} == {md5!r}", file=sys.stderr)
         return True
 
-    raise AssertionError(
-        "MD5 doesn't match:\nactual: {}\nexpected: {}".format(md5_actual, md5)
-    )
+    raise AssertionError(f"MD5 doesn't match:\nactual: {md5_actual}\nexpected: {md5}")
 
 
 def cached_download(
@@ -81,7 +79,7 @@ def cached_download(
     # check existence
     if osp.exists(path) and not md5:
         if not quiet:
-            print("File exists: {}".format(path), file=sys.stderr)
+            print(f"File exists: {path}", file=sys.stderr)
         return path
     elif osp.exists(path) and md5:
         try:
@@ -104,9 +102,9 @@ def cached_download(
         if not quiet:
             msg = "Cached Downloading"
             if path:
-                msg = "{}: {}".format(msg, path)
+                msg = f"{msg}: {path}"
             else:
-                msg = "{}...".format(msg)
+                msg = f"{msg}..."
             print(msg, file=sys.stderr)
 
         download(url, temp_path, quiet=quiet, **kwargs)

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -58,9 +58,8 @@ def test_download_large_file_from_gdrive():
             print(e, file=sys.stderr)
             continue
     else:
-        raise AssertionError(
-            f"Failed to download any of the files: {zip(*file_id_and_md5s)[0]}"
-        )
+        file_ids, _ = zip(*file_id_and_md5s)
+        raise AssertionError(f"Failed to download any of the files: {file_ids}")
 
 
 def test_download_and_extract():

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 import tempfile
 
-from gdown.cached_download import assert_md5sum
+from gdown.cached_download import _assert_filehash
 
 here = os.path.dirname(os.path.abspath(__file__))
 
@@ -15,7 +15,7 @@ def _test_cli_with_md5(url_or_id, md5, options=None):
         if options is not None:
             cmd = f"{cmd} {options}"
         subprocess.call(shlex.split(cmd))
-        assert_md5sum(filename=f.name, md5=md5)
+        _assert_filehash(path=f.name, hash=f"md5:{md5}")
 
 
 def _test_cli_with_content(url_or_id, content):

--- a/tests/test_cached_download.py
+++ b/tests/test_cached_download.py
@@ -1,0 +1,24 @@
+import tempfile
+
+import gdown
+
+
+def _cached_download(**kwargs):
+    url = "https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c"
+    with tempfile.NamedTemporaryFile() as f:
+        for _ in range(2):
+            gdown.cached_download(url=url, path=f.name, **kwargs)
+
+
+def test_cached_download_md5():
+    _cached_download(hash="md5:cb31a703b96c1ab2f80d164e9676fe7d")
+
+
+def test_cached_download_sha1():
+    _cached_download(hash="sha1:69a5a1000f98237efea9231c8a39d05edf013494")
+
+
+def test_cached_download_sha256():
+    _cached_download(
+        hash="sha256:284e3029cce3ae5ee0b05866100e300046359f53ae4c77fe6b34c05aa7a72cee"
+    )


### PR DESCRIPTION
- Will support md5, sha1, sha256, ...

Usage:

```python
# Old
gdown.cached_download(
    url=url,
    md5="xxxx...xxxx",
)

# New
gdown.cached_download(
    url=url,
    hash="md5:xxxx....xxxx",
)
gdown.cached_download(
    url=url,
    hash="sha1:xxxx....xxxx",
)
gdown.cached_download(
    url=url,
    hash="sha256:xxxx....xxxx",
)
```