### PR TITLE
BUG: Download folder with "skip_download=True" creates an output folder

### DIFF
--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -290,7 +290,7 @@ def download_folder(
         root_dir = osp.join(output, gdrive_file.name)
     else:
         root_dir = output
-    if not osp.exists(root_dir):
+    if not skip_download and not osp.exists(root_dir):
         os.makedirs(root_dir)
 
     files = []


### PR DESCRIPTION
Let's say that we want to check what's inside a folder named "output", if the folder "output" does not exist yet on the machine, it is created. This behavior does not seem useful to gdown practitioners.

Thanks a lot!