### PR TITLE
New feature: Skip existed files when downloading folders

### DIFF
--- a/gdown/download.py
+++ b/gdown/download.py
@@ -112,6 +112,7 @@ def download(
     format=None,
     user_agent=None,
     log_messages=None,
+    skip_existed=True,
 ):
     """Download file from URL.
 
@@ -151,7 +152,10 @@ def download(
         Log messages to customize. Currently it supports:
         - 'start': the message to show the start of the download
         - 'output': the message to show the output filename
-
+    skip_existed: bool, optional
+        If True, skip the files that have already been downloaded.
+        Default to True.
+        
     Returns
     -------
     output: str
@@ -271,13 +275,18 @@ def download(
 
     if output is None:
         output = filename_from_url
-
+        
     output_is_path = isinstance(output, str)
     if output_is_path and output.endswith(osp.sep):
         if not osp.exists(output):
             os.makedirs(output)
         output = osp.join(output, filename_from_url)
-
+        
+    if skip_existed and os.path.exists(output):
+        if not quiet:
+            print(f"Skip existed file: {output}.")
+        continue
+        
     if output_is_path:
         existing_tmp_files = []
         for file in os.listdir(osp.dirname(output) or "."):

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -209,7 +209,7 @@ def download_folder(
     verify=True,
     user_agent=None,
     skip_download: bool = False,
-    skip_existed: bool = False,
+    skip_existed: bool = True,
 ) -> Union[List[str], List[GoogleDriveFileToDownload], None]:
     """Downloads entire folder from URL.
 
@@ -242,7 +242,7 @@ def download_folder(
         Defaults to False
     skip_existed: bool, optional
         If True, skip the files that have already been downloaded.
-        Default to False.
+        Default to True.
 
     Returns
     -------

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -209,6 +209,7 @@ def download_folder(
     verify=True,
     user_agent=None,
     skip_download: bool = False,
+    skip_existed: bool = False,
 ) -> Union[List[str], List[GoogleDriveFileToDownload], None]:
     """Downloads entire folder from URL.
 
@@ -238,7 +239,10 @@ def download_folder(
         User-agent to use in the HTTP request.
     skip_download: bool, optional
         If True, return the list of files to download without downloading them.
-        Defaults to False.
+        Defaults to False
+    skip_existed: bool, optional
+        If True, skip the files that have already been downloaded.
+        Default to False.
 
     Returns
     -------
@@ -296,7 +300,12 @@ def download_folder(
     files = []
     for id, path in directory_structure:
         local_path = osp.join(root_dir, path)
-
+        
+        if skip_existed and os.path.exists(local_path):
+            if not quiet:
+                print(f"Skip existed file: {local_path}.")
+            continue
+            
         if id is None:  # folder
             if not skip_download and not osp.exists(local_path):
                 os.makedirs(local_path)


### PR DESCRIPTION
# Background
Due to some accidents, some users encounter the problems that the download tasks break up unexpectedly. When downloading just a single file, it is acceptable to re-download it from the beginning. However, when downloading a folder, it is a waste of time to re-download the files downloaded before the break.

# Update:
- Add a new parameter `skip_existed` to the function `download_folder()`.
- Print the skipped files if `quite` is set to False.

# Example Python Snippet:

```python
import gdown
import os

output_dir = "./xxx/your_target_dir"
if not os.path.exists(output_dir):
    os.makedirs(output_dir)
url = "https://drive.google.com/drive/folders/xxxxxxxxxxxxxxxxxxxxx=sharing"
gdown.download_folder(url, output=output_dir, remaining_ok=True, quite=False, skip_existed=True)
```
