### PR TITLE
Show resume progress bar from the middle

### DIFF
--- a/gdown/download.py
+++ b/gdown/download.py
@@ -314,8 +314,11 @@ def download(
         f = output
 
     if tmp_file is not None and f.tell() != 0:
-        headers = {"Range": "bytes={}-".format(f.tell())}
+        start_size = f.tell()
+        headers = {"Range": "bytes={}-".format(start_size)}
         res = sess.get(url, headers=headers, stream=True, verify=verify)
+    else:
+        start_size = 0
 
     if not quiet:
         print(log_messages.get("start", "Downloading...\n"), file=sys.stderr, end="")
@@ -337,9 +340,9 @@ def download(
     try:
         total = res.headers.get("Content-Length")
         if total is not None:
-            total = int(total)
+            total = int(total) + start_size
         if not quiet:
-            pbar = tqdm.tqdm(total=total, unit="B", unit_scale=True)
+            pbar = tqdm.tqdm(total=total, unit="B", initial=start_size, unit_scale=True)
         t_start = time.time()
         for chunk in res.iter_content(chunk_size=CHUNK_SIZE):
             f.write(chunk)


### PR DESCRIPTION
## Why?

- More understandable.
- I found this via https://github.com/wkentaro/gdown/issues/350

## Before -> After


<img width="1822" alt="image" src="https://github.com/wkentaro/gdown/assets/4310419/d0a49f9b-5fce-4bcd-b2e9-c7fa91182803">



![image](https://github.com/wkentaro/gdown/assets/4310419/4b870759-4506-4d09-ad20-641d7c1646c1)
