### PR TITLE
Fix folder downloads entirely not working

### DIFF
--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -182,13 +182,16 @@ def _get_directory_structure(gdrive_file, previous_path):
 
     directory_structure = []
     for file in gdrive_file.children:
-        file.name = file.name.replace(osp.sep, "_")
+        # Replace path separators and remove leading/trailing whitespace
+        file.name = file.name.replace(osp.sep, "_").strip()
         if file.is_folder():
-            directory_structure.append((None, osp.join(previous_path, file.name)))
-            for i in _get_directory_structure(file, osp.join(previous_path, file.name)):
+            new_path = osp.join(previous_path, file.name)
+            directory_structure.append((None, new_path))
+            for i in _get_directory_structure(file, new_path):
                 directory_structure.append(i)
         elif not file.children:
-            directory_structure.append((file.id, osp.join(previous_path, file.name)))
+            new_path = osp.join(previous_path, file.name)
+            directory_structure.append((file.id, new_path))
     return directory_structure
 
 


### PR DESCRIPTION
In my experience, gdown would add a random space at the end of directory names that prevented it from functioning properly and exiting when trying to download folders.
![image](https://github.com/wkentaro/gdown/assets/57060018/0d5e3919-5bdd-46e7-90fe-741c7aa141e8)
