### PR TITLE
Replace `findChildren` with `find_all`

### DIFF
--- a/gdown/download.py
+++ b/gdown/download.py
@@ -36,7 +36,7 @@ def get_url_from_gdrive_confirmation(contents):
             url = form["action"].replace("&amp;", "&")
             url_components = urllib.parse.urlsplit(url)
             query_params = urllib.parse.parse_qs(url_components.query)
-            for param in form.findChildren("input", attrs={"type": "hidden"}):
+            for param in form.find_all("input", attrs={"type": "hidden"}):
                 query_params[param["name"]] = param["value"]
             query = urllib.parse.urlencode(query_params, doseq=True)
             url = urllib.parse.urlunsplit(url_components._replace(query=query))


### PR DESCRIPTION
`findChildren` is deprecated since version 3.0.0 of `bs4` as reported [here](https://git.launchpad.net/beautifulsoup/tree/bs4/element.py#n2756). It seems that this method will be remove starting from version 4.15.0 of `bs4` as reported [here](https://git.launchpad.net/beautifulsoup/tree/CHANGELOG#n87).

These `DeprecationWarning`s are thrown when `gdown` is run with
```bash
export PYTHONWARNINGS=always
```