### PR TITLE
remove / from filenames that have them

### DIFF
--- a/gdown/download.py
+++ b/gdown/download.py
@@ -67,6 +67,7 @@ def _get_filename_from_response(response):
     m = re.search(r"filename\*=UTF-8''(.*)", content_disposition)
     if m:
         filename = m.groups()[0]
+        filename = filename.replace("/", " ")
         return filename.replace(osp.sep, "_")
 
     m = re.search('attachment; filename="(.*?)"', content_disposition)


### PR DESCRIPTION
This is my proposed change to fix issue 393 where Windows throws path not found errors when downloading a google doc that has a forward slash in the filename.  I've tested on Linux and Windows and haven't had any issues with the one line I added in download.py file.  Here's a link to the issue that I'm talking about: https://github.com/wkentaro/gdown/issues/393