### PR TITLE
Fix: Speed limit bugs with `--continue` and `--quiet`

### DIFF
--- a/gdown/download.py
+++ b/gdown/download.py
@@ -365,12 +365,14 @@ def download(
         if not quiet:
             pbar = tqdm.tqdm(total=total, unit="B", initial=start_size, unit_scale=True)
         t_start = time.time()
+        downloaded = 0
         for chunk in res.iter_content(chunk_size=CHUNK_SIZE):
             f.write(chunk)
+            downloaded += len(chunk)
             if not quiet:
                 pbar.update(len(chunk))
             if speed is not None:
-                elapsed_time_expected = 1.0 * (pbar.n - start_size) / speed
+                elapsed_time_expected = downloaded / speed
                 elapsed_time = time.time() - t_start
                 if elapsed_time < elapsed_time_expected:
                     time.sleep(elapsed_time_expected - elapsed_time)

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -370,7 +370,7 @@ def download(
             if not quiet:
                 pbar.update(len(chunk))
             if speed is not None:
-                elapsed_time_expected = 1.0 * pbar.n / speed
+                elapsed_time_expected = 1.0 * (pbar.n - start_size) / speed
                 elapsed_time = time.time() - t_start
                 if elapsed_time < elapsed_time_expected:
                     time.sleep(elapsed_time_expected - elapsed_time)


### PR DESCRIPTION
This PR fixes two related issues when speed limit is enabled (`--speed`):

1. **Download stalls on resumed downloads (`--continue`)**
When resuming partially downloaded file, the downloader sleeps unnecessarily to make up for previously downloaded data. For example resuming from 50MB with a 1MB/s speed limit would delay for 50 seconds before continuing.

2. **`UnboundLocalError` is raised when `--quiet` is enabled**
The throttling logic was referencing the progress bar (`pbar.n`) to calculate the expected elapsed time, but `pbar` is only instantiated when `quiet` is set to `False`, which raised the error. So we need to track the downloaded bytes separately from the progress bar.
