### PR TITLE
feat: add progress callback to download()

### DIFF
--- a/gdown/download.py
+++ b/gdown/download.py
@@ -8,6 +8,7 @@ import tempfile
 import textwrap
 import time
 import urllib.parse
+from collections.abc import Callable
 from http.cookiejar import MozillaCookieJar
 
 import bs4
@@ -130,6 +131,7 @@ def download(
     format=None,
     user_agent=None,
     log_messages=None,
+    progress: Callable[[int, int | None], None] | None = None,
 ):
     """Download file from URL.
 
@@ -171,6 +173,10 @@ def download(
         Log messages to customize. Currently it supports:
         - 'start': the message to show the start of the download
         - 'output': the message to show the output filename
+    progress: callable, optional
+        Callback called after each chunk: ``progress(bytes_so_far, bytes_total)``.
+        *bytes_total* is None when Content-Length is unavailable.
+        Raise any exception from the callback to abort the download.
 
     Returns
     -------
@@ -380,6 +386,8 @@ def download(
             downloaded += len(chunk)
             if not quiet:
                 pbar.update(len(chunk))
+            if progress is not None:
+                progress(downloaded + start_size, total)
             if speed is not None:
                 elapsed_time_expected = downloaded / speed
                 elapsed_time = time.time() - t_start

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,12 +1,49 @@
 import os
 import tempfile
+from collections.abc import Iterator
+from typing import NamedTuple
+
+import pytest
 
 from gdown.download import download
 
 
-def test_download():
+class DownloadEnv(NamedTuple):
+    file_path: str
+    url: str
+
+
+@pytest.fixture()
+def download_env() -> Iterator[DownloadEnv]:
     with tempfile.TemporaryDirectory() as d:
-        file_path = os.path.join(d, "file")
-        url = "https://raw.githubusercontent.com/wkentaro/gdown/3.1.0/gdown/__init__.py"  # NOQA
-        # Usage before https://github.com/wkentaro/gdown/pull/32
-        assert download(url=url, output=file_path, quiet=False) == file_path
+        yield DownloadEnv(
+            file_path=os.path.join(d, "file"),
+            url="https://raw.githubusercontent.com/wkentaro/gdown/3.1.0/gdown/__init__.py",
+        )
+
+
+def test_download(download_env: DownloadEnv) -> None:
+    # Usage before https://github.com/wkentaro/gdown/pull/32
+    assert (
+        download(url=download_env.url, output=download_env.file_path, quiet=False)
+        == download_env.file_path
+    )
+
+
+def test_download_progress(download_env: DownloadEnv) -> None:
+    reported: list[tuple[int, int | None]] = []
+    download(
+        url=download_env.url,
+        output=download_env.file_path,
+        quiet=True,
+        progress=lambda current, total: reported.append((current, total)),
+    )
+
+    assert len(reported) >= 1
+
+    currents = [c for c, _ in reported]
+    assert currents == sorted(currents)
+
+    final_current, final_total = reported[-1]
+    assert final_total is not None
+    assert final_current == os.path.getsize(download_env.file_path)


### PR DESCRIPTION
## Summary
- Add `progress` callback parameter to `download()` that is called after each chunk: `progress(bytes_so_far, bytes_total)`
- `cached_download()` gets it for free via `**kwargs`
- Callers can abort by raising from the callback

## Why
GUI applications (e.g., labelme) that call `gdown.download()` or `gdown.cached_download()` have no way to observe download progress without monkey-patching tqdm. A simple callback is the most universal hook — any UI framework (Qt, tkinter, web) can consume `(current, total)`. Pass `quiet=True` + `progress=fn` to fully replace tqdm with a custom UI.

## Test plan
- [x] `pytest tests/test_download.py -v` — 2/2 passed
- [x] Verified progress callback receives monotonically increasing `current` values
- [x] Verified final `current` matches actual file size on disk
- [x] Reviewed by fresh Claude Code instance (3 cycles, LGTM)