### PR TITLE
refactor: replace custom _indent with textwrap.indent

### DIFF
--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -8,7 +8,6 @@ import warnings
 import requests
 
 from . import __version__
-from ._indent import indent
 from .download import download
 from .download_folder import MAX_NUMBER_FILES
 from .download_folder import download_folder
@@ -185,7 +184,7 @@ def main():
         print(
             "Failed to retrieve folder contents:\n\n{}\n\n"
             "You can use `--remaining-ok` option to ignore this error.".format(
-                indent("\n".join(textwrap.wrap(str(e))), prefix="\t")
+                textwrap.indent("\n".join(textwrap.wrap(str(e))), prefix="\t")
             ),
             file=sys.stderr,
         )
@@ -193,7 +192,7 @@ def main():
     except requests.exceptions.ProxyError as e:
         print(
             "Failed to use proxy:\n\n{}\n\nPlease check your proxy settings.".format(
-                indent("\n".join(textwrap.wrap(str(e))), prefix="\t")
+                textwrap.indent("\n".join(textwrap.wrap(str(e))), prefix="\t")
             ),
             file=sys.stderr,
         )
@@ -202,7 +201,7 @@ def main():
         print(
             "Error:\n\n{}\n\nTo report issues, please visit "
             "https://github.com/wkentaro/gdown/issues.".format(
-                indent("\n".join(textwrap.wrap(str(e))), prefix="\t")
+                textwrap.indent("\n".join(textwrap.wrap(str(e))), prefix="\t")
             ),
             file=sys.stderr,
         )

--- a/gdown/_indent.py
+++ b/gdown/_indent.py
@@ -1,7 +1,0 @@
-# textwrap.indent for Python2
-def indent(text, prefix):
-    def prefixed_lines():
-        for line in text.splitlines(True):
-            yield (prefix + line if line.strip() else line)
-
-    return "".join(prefixed_lines())

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -15,7 +15,6 @@ import bs4
 import requests
 import tqdm
 
-from ._indent import indent
 from .exceptions import FileURLRetrievalError
 from .parse_url import parse_url
 
@@ -285,7 +284,7 @@ def download(
                 "\n\n\t{}\n\n"
                 "but Gdown can't. Please check connections and permissions."
             ).format(
-                indent("\n".join(textwrap.wrap(str(e))), prefix="\t"),
+                textwrap.indent("\n".join(textwrap.wrap(str(e))), prefix="\t"),
                 url_origin,
             )
             raise FileURLRetrievalError(message)


### PR DESCRIPTION
## Summary
- Delete `gdown/_indent.py` (Python 2 polyfill for `textwrap.indent`)
- Replace `from ._indent import indent` with `textwrap.indent()` in `__main__.py` and `download.py`

## Why
The custom `_indent` module was a Python 2 compatibility shim. Since gdown now requires Python 3.10+, the stdlib `textwrap.indent` (available since 3.3) is a drop-in replacement with identical behavior.

## Test plan
- [x] Verified `_indent.indent` and `textwrap.indent` have identical default predicate logic
- [x] Confirmed no remaining references to `_indent` in the codebase
- [x] Confirmed `_indent` was never publicly exported (`__init__.py`, `dir(gdown)`)
- [x] `import gdown` succeeds
- [x] `pytest` passes (1 pre-existing network-dependent failure unrelated to this change)