### PR TITLE
refactor: add type annotations to all function signatures

### DIFF
--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -4,6 +4,8 @@ import re
 import sys
 import textwrap
 import warnings
+from collections.abc import Sequence
+from typing import Any
 
 import requests
 
@@ -16,12 +18,18 @@ from .exceptions import FolderContentsMaximumLimitError
 
 
 class _ShowVersionAction(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: str | Sequence[Any] | None,
+        option_string: str | None = None,
+    ) -> None:
         print(f"gdown {__version__} at {os.path.dirname(os.path.dirname(__file__))}")
         parser.exit()
 
 
-def file_size(argv):
+def file_size(argv: str | None) -> float | None:
     if argv is not None:
         m = re.match(r"([0-9]+)(GB|MB|KB|B)", argv)
         if not m:
@@ -39,7 +47,7 @@ def file_size(argv):
         return size
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
@@ -149,6 +157,8 @@ def main():
 
     try:
         if args.folder:
+            if not (args.output is None or isinstance(args.output, str)):
+                raise ValueError("--folder does not support stdout output (-O -)")
             download_folder(
                 url=url,
                 id=id,

--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 import os
 import os.path as osp
@@ -5,10 +7,31 @@ import shutil
 import sys
 import tempfile
 import warnings
+from collections.abc import Callable
+from typing import TypedDict
+
+if sys.version_info >= (3, 12):
+    from typing import Unpack
+else:
+    from typing_extensions import Unpack
 
 import filelock
 
 from .download import download
+
+
+class _DownloadKwargs(TypedDict, total=False):
+    proxy: str | None
+    speed: float | None
+    use_cookies: bool
+    verify: bool | str
+    id: str | None
+    fuzzy: bool
+    resume: bool
+    format: str | None
+    user_agent: str | None
+    progress: Callable[[int, int | None], None] | None
+
 
 cache_root = osp.join(osp.expanduser("~"), ".cache/gdown")
 if not osp.exists(cache_root):
@@ -18,7 +41,7 @@ if not osp.exists(cache_root):
         pass
 
 
-def md5sum(filename, blocksize=None):
+def md5sum(filename: str, blocksize: int | None = None) -> str:
     warnings.warn(
         "md5sum is deprecated and will be removed in the future.", FutureWarning
     )
@@ -33,7 +56,9 @@ def md5sum(filename, blocksize=None):
     return hash.hexdigest()
 
 
-def assert_md5sum(filename, md5, quiet=False, blocksize=None):
+def assert_md5sum(
+    filename: str, md5: str, quiet: bool = False, blocksize: int | None = None
+) -> bool:
     warnings.warn(
         "assert_md5sum is deprecated and will be removed in the future.", FutureWarning
     )
@@ -52,14 +77,14 @@ def assert_md5sum(filename, md5, quiet=False, blocksize=None):
 
 
 def cached_download(
-    url=None,
-    path=None,
-    md5=None,
-    quiet=False,
-    postprocess=None,
+    url: str | None = None,
+    path: str | None = None,
+    md5: str | None = None,
+    quiet: bool = False,
+    postprocess: Callable[[str], None] | None = None,
     hash: str | None = None,
-    **kwargs,
-):
+    **kwargs: Unpack[_DownloadKwargs],
+) -> str:
     """Cached download from URL.
 
     Parameters
@@ -156,7 +181,7 @@ def cached_download(
     return path
 
 
-def _compute_filehash(path, algorithm):
+def _compute_filehash(path: str, algorithm: str) -> str:
     BLOCKSIZE = 65536
 
     if algorithm not in hashlib.algorithms_guaranteed:
@@ -172,7 +197,9 @@ def _compute_filehash(path, algorithm):
     return f"{algorithm}:{algorithm_instance.hexdigest()}"
 
 
-def _assert_filehash(path, hash, quiet=False, blocksize=None):
+def _assert_filehash(
+    path: str, hash: str, quiet: bool = False, blocksize: int | None = None
+) -> bool:
     if ":" not in hash:
         raise ValueError(
             f"Invalid hash: {hash}. "

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -1,3 +1,4 @@
+import datetime
 import email.utils
 import os
 import os.path as osp
@@ -10,6 +11,9 @@ import time
 import urllib.parse
 from collections.abc import Callable
 from http.cookiejar import MozillaCookieJar
+from typing import BinaryIO
+from typing import Literal
+from typing import overload
 
 import bs4
 import requests
@@ -22,7 +26,7 @@ CHUNK_SIZE = 512 * 1024  # 512KB
 home = osp.expanduser("~")
 
 
-def get_url_from_gdrive_confirmation(contents):
+def get_url_from_gdrive_confirmation(contents: str) -> str:
     url = ""
     for line in contents.splitlines():
         m = re.search(r'href="(\/uc\?export=download[^"]+)', line)
@@ -67,7 +71,7 @@ def get_url_from_gdrive_confirmation(contents):
     return url
 
 
-def _get_filename_from_response(response):
+def _get_filename_from_response(response: requests.Response) -> str | None:
     content_disposition = urllib.parse.unquote(response.headers["Content-Disposition"])
 
     m = re.search(r"filename\*=UTF-8''(.*)", content_disposition)
@@ -83,7 +87,9 @@ def _get_filename_from_response(response):
     return None
 
 
-def _get_modified_time_from_response(response):
+def _get_modified_time_from_response(
+    response: requests.Response,
+) -> datetime.datetime | None:
     if "Last-Modified" not in response.headers:
         return None
 
@@ -94,7 +100,30 @@ def _get_modified_time_from_response(response):
     return email.utils.parsedate_to_datetime(raw)
 
 
-def _get_session(proxy, use_cookies, user_agent, return_cookies_file=False):
+@overload
+def _get_session(
+    proxy: str | None,
+    use_cookies: bool,
+    user_agent: str,
+    return_cookies_file: Literal[False] = ...,
+) -> requests.Session: ...
+
+
+@overload
+def _get_session(
+    proxy: str | None,
+    use_cookies: bool,
+    user_agent: str,
+    return_cookies_file: Literal[True],
+) -> tuple[requests.Session, str]: ...
+
+
+def _get_session(
+    proxy: str | None,
+    use_cookies: bool,
+    user_agent: str,
+    return_cookies_file: bool = False,
+) -> requests.Session | tuple[requests.Session, str]:
     sess = requests.session()
 
     sess.headers.update({"User-Agent": user_agent})
@@ -117,21 +146,21 @@ def _get_session(proxy, use_cookies, user_agent, return_cookies_file=False):
 
 
 def download(
-    url=None,
-    output=None,
-    quiet=False,
-    proxy=None,
-    speed=None,
-    use_cookies=True,
-    verify=True,
-    id=None,
-    fuzzy=False,
-    resume=False,
-    format=None,
-    user_agent=None,
-    log_messages=None,
+    url: str | None = None,
+    output: str | BinaryIO | None = None,
+    quiet: bool = False,
+    proxy: str | None = None,
+    speed: float | None = None,
+    use_cookies: bool = True,
+    verify: bool | str = True,
+    id: str | None = None,
+    fuzzy: bool = False,
+    resume: bool = False,
+    format: str | None = None,
+    user_agent: str | None = None,
+    log_messages: dict[str, str] | None = None,
     progress: Callable[[int, int | None], None] | None = None,
-):
+) -> str | BinaryIO | None:
     """Download file from URL.
 
     Parameters
@@ -396,6 +425,7 @@ def download(
             pbar.close()
         if tmp_file:
             f.close()
+            assert isinstance(output, str)
             shutil.move(tmp_file, output)
         if isinstance(output, str) and last_modified_time:
             mtime = last_modified_time.timestamp()

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import itertools
 import json
@@ -8,6 +10,7 @@ import sys
 import warnings
 
 import bs4
+import requests
 
 from .download import _get_session
 from .download import download
@@ -20,17 +23,25 @@ MAX_NUMBER_FILES = 50
 class _GoogleDriveFile:
     TYPE_FOLDER = "application/vnd.google-apps.folder"
 
-    def __init__(self, id, name, type, children=None):
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        type: str,
+        children: list[_GoogleDriveFile] | None = None,
+    ) -> None:
         self.id = id
         self.name = name
         self.type = type
         self.children = children if children is not None else []
 
-    def is_folder(self):
+    def is_folder(self) -> bool:
         return self.type == self.TYPE_FOLDER
 
 
-def _parse_google_drive_file(url, content):
+def _parse_google_drive_file(
+    url: str, content: str
+) -> tuple[_GoogleDriveFile, list[tuple[str, str, str]]]:
     """Extracts information about the current page file and its children."""
 
     folder_soup = bs4.BeautifulSoup(content, features="html.parser")
@@ -94,12 +105,12 @@ def _parse_google_drive_file(url, content):
 
 
 def _download_and_parse_google_drive_link(
-    sess,
-    url,
-    quiet=False,
-    remaining_ok=False,
-    verify=True,
-):
+    sess: requests.Session,
+    url: str,
+    quiet: bool = False,
+    remaining_ok: bool = False,
+    verify: bool | str = True,
+) -> tuple[bool, _GoogleDriveFile | None]:
     """Get folder structure of Google Drive folder URL."""
 
     return_code = True
@@ -163,6 +174,7 @@ def _download_and_parse_google_drive_link(
         )
         if not return_code:
             return return_code, None
+        assert child is not None
         gdrive_file.children.append(child)
     has_at_least_max_files = len(gdrive_file.children) == MAX_NUMBER_FILES
     if not remaining_ok and has_at_least_max_files:
@@ -177,7 +189,9 @@ def _download_and_parse_google_drive_link(
     return return_code, gdrive_file
 
 
-def _get_directory_structure(gdrive_file, previous_path):
+def _get_directory_structure(
+    gdrive_file: _GoogleDriveFile, previous_path: str
+) -> list[tuple[str | None, str]]:
     """Converts a Google Drive folder structure into a local directory list."""
 
     directory_structure = []
@@ -198,18 +212,18 @@ GoogleDriveFileToDownload = collections.namedtuple(
 
 
 def download_folder(
-    url=None,
-    id=None,
-    output=None,
-    quiet=False,
-    proxy=None,
-    speed=None,
-    use_cookies=True,
-    remaining_ok=False,
-    verify=True,
-    user_agent=None,
+    url: str | None = None,
+    id: str | None = None,
+    output: str | None = None,
+    quiet: bool = False,
+    proxy: str | None = None,
+    speed: float | None = None,
+    use_cookies: bool = True,
+    remaining_ok: bool = False,
+    verify: bool | str = True,
+    user_agent: str | None = None,
     skip_download: bool = False,
-    resume=False,
+    resume: bool = False,
 ) -> list[str] | list[GoogleDriveFileToDownload] | None:
     """Downloads entire folder from URL.
 
@@ -264,6 +278,7 @@ def download_folder(
         raise ValueError("Either url or id has to be specified")
     if id is not None:
         url = f"https://drive.google.com/drive/folders/{id}"
+    assert url is not None
     if user_agent is None:
         # We need to use different user agent for folder download c.f., file
         user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"  # NOQA: E501
@@ -282,6 +297,7 @@ def download_folder(
     if not is_success:
         print("Failed to retrieve folder contents", file=sys.stderr)
         return None
+    assert gdrive_file is not None
 
     if not quiet:
         print("Retrieving folder contents completed", file=sys.stderr)

--- a/gdown/extractall.py
+++ b/gdown/extractall.py
@@ -3,7 +3,7 @@ import tarfile
 import zipfile
 
 
-def extractall(path, to=None):
+def extractall(path: str, to: str | None = None) -> list[str]:
     """Extract archive file.
 
     Parameters

--- a/gdown/parse_url.py
+++ b/gdown/parse_url.py
@@ -3,12 +3,12 @@ import urllib.parse
 import warnings
 
 
-def is_google_drive_url(url):
+def is_google_drive_url(url: str) -> bool:
     parsed = urllib.parse.urlparse(url)
     return parsed.hostname in ["drive.google.com", "docs.google.com"]
 
 
-def parse_url(url, warning=True):
+def parse_url(url: str, warning: bool = True) -> tuple[str | bool | None, bool]:
     """Parse URLs especially for Google Drive links.
 
     file_id: ID of file on Google Drive.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,13 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = ["filelock", "requests[socks]", "tqdm", "beautifulsoup4"]
+dependencies = [
+  "beautifulsoup4",
+  "filelock",
+  "requests[socks]",
+  "tqdm",
+  "typing_extensions>=4.0; python_version < '3.12'",
+]
 dynamic = ["readme", "version"]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,11 +60,11 @@ fragments = [{ path = "README.md" }]
 
 [tool.ruff.lint]
 select = [
-  # "ANN", # flake8-annotations
-  "E",  # pycodestyle
-  "F",  # pyflakes
-  "I",  # isort
-  "UP", # pyupgrade
+  "ANN", # flake8-annotations
+  "E",   # pycodestyle
+  "F",   # pyflakes
+  "I",   # isort
+  "UP",  # pyupgrade
 ]
 
 [tool.ruff.lint.isort]

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -10,7 +10,9 @@ from gdown.cached_download import _compute_filehash
 here = os.path.dirname(os.path.abspath(__file__))
 
 
-def _test_cli_with_md5(url_or_id, md5, options=None):
+def _test_cli_with_md5(
+    url_or_id: str, md5: str, options: list[str] | None = None
+) -> None:
     # We can't use NamedTemporaryFile because Windows doesn't allow the subprocess
     # to write the file created by the parent process.
     with tempfile.TemporaryDirectory() as d:
@@ -22,7 +24,7 @@ def _test_cli_with_md5(url_or_id, md5, options=None):
         _assert_filehash(path=file_path, hash=f"md5:{md5}")
 
 
-def _test_cli_with_content(url_or_id, content):
+def _test_cli_with_content(url_or_id: str, content: str) -> None:
     # We can't use NamedTemporaryFile because Windows doesn't allow the subprocess
     # to write the file created by the parent process.
     with tempfile.TemporaryDirectory() as d:
@@ -33,13 +35,13 @@ def _test_cli_with_content(url_or_id, content):
             assert f.read() == content
 
 
-def test_download_from_url_other_than_gdrive():
+def test_download_from_url_other_than_gdrive() -> None:
     url = "https://raw.githubusercontent.com/wkentaro/gdown/3.1.0/gdown/__init__.py"
     md5 = "2a51927dde6b146ce56b4d89ebbb5268"
     _test_cli_with_md5(url_or_id=url, md5=md5)
 
 
-def test_download_small_file_from_gdrive():
+def test_download_small_file_from_gdrive() -> None:
     with open(os.path.join(here, "data/file_ids.csv")) as f:
         file_ids = [file_id.strip() for file_id in f]
 
@@ -54,7 +56,7 @@ def test_download_small_file_from_gdrive():
         raise AssertionError(f"Failed to download any of the files: {file_ids}")
 
 
-def test_download_large_file_from_gdrive():
+def test_download_large_file_from_gdrive() -> None:
     with open(os.path.join(here, "data/file_ids_large.csv")) as f:
         file_id_and_md5s = [[x.strip() for x in file_id.split(",")] for file_id in f]
 
@@ -70,14 +72,14 @@ def test_download_large_file_from_gdrive():
         raise AssertionError(f"Failed to download any of the files: {file_ids}")
 
 
-def test_download_and_extract():
+def test_download_and_extract() -> None:
     cmd = "gdown --no-cookies https://github.com/wkentaro/gdown/archive/refs/tags/v4.0.0.tar.gz -O - | tar zxvf -"  # noqa: E501
     with tempfile.TemporaryDirectory() as d:
         subprocess.call(cmd, shell=True, cwd=d)
         assert os.path.exists(os.path.join(d, "gdown-4.0.0/gdown/__init__.py"))
 
 
-def test_download_folder_from_gdrive():
+def test_download_folder_from_gdrive() -> None:
     with open(os.path.join(here, "data/folder_ids.csv")) as f:
         folder_id_and_md5s = [
             [x.strip() for x in folder_id.split(",")] for folder_id in f
@@ -109,7 +111,7 @@ def test_download_folder_from_gdrive():
         raise AssertionError(f"Failed to download any of the folders: {file_ids}")
 
 
-def test_download_a_folder_with_remaining_ok_false():
+def test_download_a_folder_with_remaining_ok_false() -> None:
     with tempfile.TemporaryDirectory() as d:
         cmd = [
             "gdown",
@@ -134,13 +136,13 @@ def test_download_a_folder_with_remaining_ok_false():
 #     _test_cli_with_md5(url_or_id=file_id, md5=md5, options="--format pdf")
 
 
-def test_download_slides_from_gdrive():
+def test_download_slides_from_gdrive() -> None:
     file_id = "13AhW1Z1GYGaiTpJ0Pr2TTXoQivb6jx-a"
     md5 = "96704c6c40e308a68d3842e83a0136b9"
     _test_cli_with_md5(url_or_id=file_id, md5=md5, options=["--format", "pdf"])
 
 
-def test_download_a_folder_with_file_content_more_than_the_limit():
+def test_download_a_folder_with_file_content_more_than_the_limit() -> None:
     url = "https://drive.google.com/drive/folders/1gd3xLkmjT8IckN6WtMbyFZvLR4exRIkn"
 
     with tempfile.TemporaryDirectory() as d:

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -21,6 +21,7 @@ def _test_cli_with_md5(
         if options is not None:
             cmd.extend(options)
         subprocess.call(cmd)
+        assert os.path.exists(file_path)
         _assert_filehash(path=file_path, hash=f"md5:{md5}")
 
 

--- a/tests/test_cached_download.py
+++ b/tests/test_cached_download.py
@@ -4,24 +4,24 @@ import tempfile
 import gdown
 
 
-def _cached_download(**kwargs):
+def _cached_download(hash: str) -> None:
     url = "https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c"
     fd, path = tempfile.mkstemp()
     os.close(fd)
     for _ in range(2):
-        gdown.cached_download(url=url, path=path, **kwargs)
+        gdown.cached_download(url=url, path=path, hash=hash)
     os.remove(path)
 
 
-def test_cached_download_md5():
+def test_cached_download_md5() -> None:
     _cached_download(hash="md5:cb31a703b96c1ab2f80d164e9676fe7d")
 
 
-def test_cached_download_sha1():
+def test_cached_download_sha1() -> None:
     _cached_download(hash="sha1:69a5a1000f98237efea9231c8a39d05edf013494")
 
 
-def test_cached_download_sha256():
+def test_cached_download_sha256() -> None:
     _cached_download(
         hash="sha256:284e3029cce3ae5ee0b05866100e300046359f53ae4c77fe6b34c05aa7a72cee"
     )

--- a/tests/test_download_folder.py
+++ b/tests/test_download_folder.py
@@ -7,7 +7,7 @@ from gdown.download_folder import download_folder
 here = osp.dirname(osp.abspath(__file__))
 
 
-def test_valid_page():
+def test_valid_page() -> None:
     html_file = osp.join(here, "data/folder-page-sample.html")
     with open(html_file) as f:
         content = f.read()
@@ -62,7 +62,7 @@ def test_valid_page():
     assert actual_children_types == expected_children_types
 
 
-def test_download_folder_dry_run():
+def test_download_folder_dry_run() -> None:
     url = "https://drive.google.com/drive/folders/1KpLl_1tcK0eeehzN980zbG-3M2nhbVks"
     tmp_dir = tempfile.mkdtemp()
     files = download_folder(url=url, output=tmp_dir, skip_download=True)

--- a/tests/test_parse_url.py
+++ b/tests/test_parse_url.py
@@ -3,7 +3,7 @@ import pytest
 from gdown.parse_url import parse_url
 
 
-def test_parse_url():
+def test_parse_url() -> None:
     file_id = "0B_NiLAzvehC9R2stRmQyM3ZiVjQ"
 
     # list of (url, expected, check_warn)

--- a/uv.lock
+++ b/uv.lock
@@ -215,6 +215,7 @@ dependencies = [
     { name = "filelock" },
     { name = "requests", extra = ["socks"] },
     { name = "tqdm" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 
 [package.dev-dependencies]
@@ -235,6 +236,7 @@ requires-dist = [
     { name = "filelock" },
     { name = "requests", extras = ["socks"] },
     { name = "tqdm" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- Add type annotations to every function parameter and return type across all source and test modules
- Enable the `ANN` (flake8-annotations) ruff rule to enforce annotations going forward
- Use `@overload` with `Literal[True/False]` for `_get_session` return type narrowing
- Use `TypedDict` + `Unpack` for typed `**kwargs` forwarding in `cached_download`
- Add `from __future__ import annotations` where needed for forward references

## Why
The codebase had no type annotations on function signatures. Adding them makes `ty` type checking sufficient and complete, catching bugs at lint time rather than runtime.

## Test plan
- [x] `make lint` passes (ruff format, ruff check with ANN, ty check, taplo, mdformat, yamlfix, typos)
- [x] Each commit independently passes lint
- [x] CI passes