### PR TITLE
chore: pre-release cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## Installation
 
 <a href="https://pypi.org/project/gdown"><img src="https://img.shields.io/pypi/pyversions/gdown.svg"></a>
-<a href="https://pypi.python.org/pypi/gdown"><img src="https://img.shields.io/pypi/v/gdown.svg"></a>
+<a href="https://pypi.org/project/gdown"><img src="https://img.shields.io/pypi/v/gdown.svg"></a>
 
 ```bash
 pip install gdown
@@ -35,7 +35,8 @@ pip install --upgrade gdown
 $ gdown --help
 usage: gdown [-h] [-V] [-O OUTPUT] [-q] [--fuzzy] [--id] [--proxy PROXY]
              [--speed SPEED] [--no-cookies] [--no-check-certificate]
-             [--continue] [--folder] [--remaining-ok]
+             [--continue] [--folder] [--remaining-ok] [--format FORMAT]
+             [--user-agent USER_AGENT]
              url_or_id
 ...
 
@@ -97,7 +98,7 @@ gdown.download(url=url, output=output, fuzzy=True)
 # Cached download with identity check via MD5 (or SHA1, SHA256, etc).
 # Pass postprocess function e.g., extracting compressed file.
 md5 = "md5:fa837a88f0c40c513d975104edf3da17"
-gdown.cached_download(url, output, hash=hash, postprocess=gdown.extractall)
+gdown.cached_download(url, output, hash=md5, postprocess=gdown.extractall)
 
 # a folder
 url = "https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl"

--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -197,9 +197,7 @@ def _compute_filehash(path: str, algorithm: str) -> str:
     return f"{algorithm}:{algorithm_instance.hexdigest()}"
 
 
-def _assert_filehash(
-    path: str, hash: str, quiet: bool = False, blocksize: int | None = None
-) -> bool:
+def _assert_filehash(path: str, hash: str, quiet: bool = False) -> bool:
     if ":" not in hash:
         raise ValueError(
             f"Invalid hash: {hash}. "

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -332,7 +332,7 @@ def download(
                     "Please remove them except one to resume downloading.",
                     file=sys.stderr,
                 )
-                return
+                return None
             tmp_file = existing_tmp_files[0]
         else:
             resume = False

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -156,8 +156,6 @@ def _download_and_parse_google_drive_link(
                     type=child_type,
                 )
             )
-            if not return_code:
-                return return_code, None
             continue
 
         if not quiet:
@@ -263,8 +261,9 @@ def download_folder(
     Returns
     -------
     files: List[str] or List[GoogleDriveFileToDownload] or None
-        If dry_run is False, list of local file paths downloaded or None if failed.
-        If dry_run is True, list of GoogleDriveFileToDownload that contains
+        If skip_download is False, list of local file paths downloaded
+        or None if failed.
+        If skip_download is True, list of GoogleDriveFileToDownload that contains
         id, path, and local_path.
 
     Example

--- a/gdown/parse_url.py
+++ b/gdown/parse_url.py
@@ -8,7 +8,7 @@ def is_google_drive_url(url: str) -> bool:
     return parsed.hostname in ["drive.google.com", "docs.google.com"]
 
 
-def parse_url(url: str, warning: bool = True) -> tuple[str | bool | None, bool]:
+def parse_url(url: str, warning: bool = True) -> tuple[str | None, bool]:
     """Parse URLs especially for Google Drive links.
 
     file_id: ID of file on Google Drive.
@@ -20,7 +20,7 @@ def parse_url(url: str, warning: bool = True) -> tuple[str | bool | None, bool]:
     is_download_link = parsed.path.endswith("/uc")
 
     if not is_gdrive:
-        return is_gdrive, is_download_link
+        return None, is_download_link
 
     file_id = None
     if "id" in query:


### PR DESCRIPTION
## Summary
- Fix README bug: `hash=hash` → `hash=md5` in `cached_download` example
- Update README CLI help text to include `--format` and `--user-agent`
- Normalize badge URL to canonical `pypi.org`
- Fix `parse_url` return type: return `None` instead of `False` for non-gdrive URLs
- Remove dead code in `download_folder.py` (unreachable `if not return_code` check)
- Fix stale docstring: `dry_run` → `skip_download`
- Explicit `return None` instead of bare `return` in `download.py`
- Remove unused `blocksize` param from `_assert_filehash`
- Add `py.typed` marker for PEP 561

## Why
Preparing for the next release. Cleaning up docs, dead code, and type annotations before tagging.

## Test plan
- [x] `make lint` passes (ruff, ty, taplo, mdformat, yamlfix, typos)
- [x] Non-network tests pass (parse_url, download_folder dry_run, download with httpbin)
- [ ] Network-dependent tests are flaky (Google Drive rate limiting) — unrelated to these changes