### PR TITLE
fix: return None instead of False from parse_url for non-gdrive URLs

### DIFF
--- a/gdown/parse_url.py
+++ b/gdown/parse_url.py
@@ -8,7 +8,7 @@ def is_google_drive_url(url: str) -> bool:
     return parsed.hostname in ["drive.google.com", "docs.google.com"]
 
 
-def parse_url(url: str, warning: bool = True) -> tuple[str | bool | None, bool]:
+def parse_url(url: str, warning: bool = True) -> tuple[str | None, bool]:
     """Parse URLs especially for Google Drive links.
 
     file_id: ID of file on Google Drive.
@@ -20,7 +20,7 @@ def parse_url(url: str, warning: bool = True) -> tuple[str | bool | None, bool]:
     is_download_link = parsed.path.endswith("/uc")
 
     if not is_gdrive:
-        return is_gdrive, is_download_link
+        return None, is_download_link
 
     file_id = None
     if "id" in query:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+from typing import Final
+
+GITHUB_RELEASE_URL: Final = (
+    "https://github.com/wkentaro/gdown/archive/refs/tags/v4.0.0.tar.gz"
+)

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -7,6 +7,8 @@ import tempfile
 from gdown.cached_download import _assert_filehash
 from gdown.cached_download import _compute_filehash
 
+from .conftest import GITHUB_RELEASE_URL
+
 here = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -74,7 +76,7 @@ def test_download_large_file_from_gdrive() -> None:
 
 
 def test_download_and_extract() -> None:
-    cmd = "gdown --no-cookies https://github.com/wkentaro/gdown/archive/refs/tags/v4.0.0.tar.gz -O - | tar zxvf -"  # noqa: E501
+    cmd = f"gdown --no-cookies {GITHUB_RELEASE_URL} -O - | tar zxvf -"
     with tempfile.TemporaryDirectory() as d:
         subprocess.call(cmd, shell=True, cwd=d)
         assert os.path.exists(os.path.join(d, "gdown-4.0.0/gdown/__init__.py"))

--- a/tests/test_parse_url.py
+++ b/tests/test_parse_url.py
@@ -2,6 +2,12 @@ import pytest
 
 from gdown.parse_url import parse_url
 
+from .conftest import GITHUB_RELEASE_URL
+
+
+def test_parse_url_non_gdrive() -> None:
+    assert parse_url(GITHUB_RELEASE_URL) == (None, False)
+
 
 def test_parse_url() -> None:
     file_id = "0B_NiLAzvehC9R2stRmQyM3ZiVjQ"


### PR DESCRIPTION
## Summary
- `parse_url` returned `(False, is_download_link)` for non-gdrive URLs
- The return type was `tuple[str | bool | None, bool]` — mixing `bool` and `str | None` for file_id
- Now returns `(None, is_download_link)` with clean type `tuple[str | None, bool]`

No behavior change for existing callers (all check truthiness), but the type contract is now correct.