### PR TITLE
refactor: remove dead code, fix stale docstring, cleanup returns

### DIFF
--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -197,9 +197,7 @@ def _compute_filehash(path: str, algorithm: str) -> str:
     return f"{algorithm}:{algorithm_instance.hexdigest()}"
 
 
-def _assert_filehash(
-    path: str, hash: str, quiet: bool = False, blocksize: int | None = None
-) -> bool:
+def _assert_filehash(path: str, hash: str, quiet: bool = False) -> bool:
     if ":" not in hash:
         raise ValueError(
             f"Invalid hash: {hash}. "

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -332,7 +332,7 @@ def download(
                     "Please remove them except one to resume downloading.",
                     file=sys.stderr,
                 )
-                return
+                return None
             tmp_file = existing_tmp_files[0]
         else:
             resume = False

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -156,8 +156,6 @@ def _download_and_parse_google_drive_link(
                     type=child_type,
                 )
             )
-            if not return_code:
-                return return_code, None
             continue
 
         if not quiet:
@@ -263,8 +261,9 @@ def download_folder(
     Returns
     -------
     files: List[str] or List[GoogleDriveFileToDownload] or None
-        If dry_run is False, list of local file paths downloaded or None if failed.
-        If dry_run is True, list of GoogleDriveFileToDownload that contains
+        If skip_download is False, list of local file paths downloaded
+        or None if failed.
+        If skip_download is True, list of GoogleDriveFileToDownload that contains
         id, path, and local_path.
 
     Example


### PR DESCRIPTION
## Summary
- Remove unreachable `if not return_code` check in `download_folder.py` (return_code is always True at that point)
- Fix stale docstring: `dry_run` → `skip_download` to match actual parameter name
- Explicit `return None` instead of bare `return` in `download.py`
- Remove unused `blocksize` param from `_assert_filehash`