### PR TITLE
fix: sanitize path separators in filenames cross-platform

### DIFF
--- a/gdown/download.py
+++ b/gdown/download.py
@@ -69,18 +69,20 @@ def get_url_from_gdrive_confirmation(contents: str) -> str:
     return url
 
 
+def _sanitize_filename(filename: str) -> str:
+    return filename.replace("/", "_").replace("\\", "_")
+
+
 def _get_filename_from_response(response: requests.Response) -> str | None:
     content_disposition = urllib.parse.unquote(response.headers["Content-Disposition"])
 
     m = re.search(r"filename\*=UTF-8''(.*)", content_disposition)
     if m:
-        filename = m.groups()[0]
-        return filename.replace(osp.sep, "_")
+        return _sanitize_filename(filename=m.groups()[0])
 
     m = re.search('attachment; filename="(.*?)"', content_disposition)
     if m:
-        filename = m.groups()[0]
-        return filename
+        return _sanitize_filename(filename=m.groups()[0])
 
     return None
 

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -13,6 +13,7 @@ import bs4
 import requests
 
 from .download import _get_session
+from .download import _sanitize_filename
 from .download import download
 from .exceptions import FolderContentsMaximumLimitError
 from .parse_url import is_google_drive_url
@@ -194,7 +195,7 @@ def _get_directory_structure(
 
     directory_structure = []
     for file in gdrive_file.children:
-        file.name = file.name.replace(osp.sep, "_")
+        file.name = _sanitize_filename(filename=file.name)
         if file.is_folder():
             directory_structure.append((None, osp.join(previous_path, file.name)))
             for i in _get_directory_structure(file, osp.join(previous_path, file.name)):

--- a/tests/test_get_filename_from_response.py
+++ b/tests/test_get_filename_from_response.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from gdown.download import _get_filename_from_response
+from gdown.download import _sanitize_filename
+
+
+def _make_response(content_disposition: str) -> MagicMock:
+    response = MagicMock()
+    response.headers = {"Content-Disposition": content_disposition}
+    return response
+
+
+@pytest.mark.parametrize(
+    "content_disposition, expected",
+    [
+        ("filename*=UTF-8''report.pdf", "report.pdf"),
+        ("filename*=UTF-8''Budget%2F2024.pdf", "Budget_2024.pdf"),
+        ("filename*=UTF-8''path%5Cto%5Cfile.pdf", "path_to_file.pdf"),
+        ('attachment; filename="report.pdf"', "report.pdf"),
+        ('attachment; filename="Budget/2024.pdf"', "Budget_2024.pdf"),
+        ('attachment; filename="path\\to\\file.pdf"', "path_to_file.pdf"),
+    ],
+    ids=[
+        "utf8-normal",
+        "utf8-forward-slash",
+        "utf8-backslash",
+        "attachment-normal",
+        "attachment-forward-slash",
+        "attachment-backslash",
+    ],
+)
+def test_get_filename_from_response(content_disposition: str, expected: str) -> None:
+    response = _make_response(content_disposition=content_disposition)
+    assert _get_filename_from_response(response=response) == expected
+
+
+@pytest.mark.parametrize(
+    "filename, expected",
+    [
+        ("report.pdf", "report.pdf"),
+        ("Budget/2024.pdf", "Budget_2024.pdf"),
+        ("path\\to\\file.pdf", "path_to_file.pdf"),
+        ("a/b\\c.pdf", "a_b_c.pdf"),
+    ],
+    ids=["no-op", "forward-slash", "backslash", "mixed"],
+)
+def test_sanitize_filename(filename: str, expected: str) -> None:
+    assert _sanitize_filename(filename=filename) == expected


### PR DESCRIPTION
## Summary

- Replace OS-dependent `osp.sep` replacement with explicit `/` and `\` replacement in filename sanitization, so filenames with forward slashes (allowed by Google Drive) work correctly on Windows
- Add missing sanitization to the standard `attachment; filename="..."` Content-Disposition branch, which previously returned filenames without any path separator handling
- Apply the same fix to `download_folder.py` for folder/file name sanitization
- Add unit tests for `_get_filename_from_response` covering both Content-Disposition formats with normal names, forward slashes, and backslashes

Closes #393
Supersedes #400

## Test plan

- [x] New parametrized tests for `_get_filename_from_response` (6 cases)
- [x] Existing test suite passes