### PR TITLE
fix: detect Google Docs/Sheets/Slides via URL patterns instead of page title

### DIFF
--- a/gdown/download.py
+++ b/gdown/download.py
@@ -225,8 +225,7 @@ def download(
             continue
 
         if res.headers["Content-Type"].startswith("text/html"):
-            m = re.search("<title>(.+)</title>", res.text)
-            if m and m.groups()[0].endswith(" - Google Docs"):
+            if "/document/" in res.url and "/export" not in res.url:
                 url = (
                     "https://docs.google.com/document/d/{id}/export"
                     "?format={format}".format(
@@ -235,7 +234,7 @@ def download(
                     )
                 )
                 continue
-            elif m and m.groups()[0].endswith(" - Google Sheets"):
+            elif "/spreadsheets/" in res.url and "/export" not in res.url:
                 url = (
                     "https://docs.google.com/spreadsheets/d/{id}/export"
                     "?format={format}".format(
@@ -244,7 +243,7 @@ def download(
                     )
                 )
                 continue
-            elif m and m.groups()[0].endswith(" - Google Slides"):
+            elif "/presentation/" in res.url and "/export" not in res.url:
                 url = (
                     "https://docs.google.com/presentation/d/{id}/export"
                     "?format={format}".format(


### PR DESCRIPTION
## Summary
- Replace `<title>` parsing with `res.url` pattern matching for detecting Google Docs/Sheets/Slides document types
- Use broad `/document/`, `/spreadsheets/`, `/presentation/` patterns to handle both `/d/` and `/u/N/d/` URL variants
- Guard against `/export` in URL to prevent infinite loops on failed export requests

## Why
The previous approach relied on English text in page titles (`" - Google Docs"`), which failed for non-English locales where Google localizes the title. URL path patterns are language-independent.

Supersedes #411.

## Test plan
- [x] All 17 existing tests pass
- [ ] Manual verification with Google Docs/Sheets/Slides URLs in non-English locale