### PR TITLE
fix: Windows compatibility for filenames and output directories

### DIFF
--- a/gdown/download.py
+++ b/gdown/download.py
@@ -70,7 +70,7 @@ def get_url_from_gdrive_confirmation(contents: str) -> str:
 
 
 def _sanitize_filename(filename: str) -> str:
-    return filename.replace("/", "_").replace("\\", "_")
+    return filename.replace("/", "_").replace("\\", "_").strip()
 
 
 def _get_filename_from_response(response: requests.Response) -> str | None:

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -146,8 +146,8 @@ def download(
         URL. Google Drive URL is also supported.
     output: str
         Output filename/directory. Default is basename of URL.
-        If output ends with separator '/' basename will be kept and the
-        parameter will be treated as parenting directory.
+        If output is an existing directory or ends with a path separator,
+        the basename will be appended automatically.
     quiet: bool
         Suppress terminal output. Default is False.
     proxy: str
@@ -304,7 +304,7 @@ def download(
     if output is None:
         output = filename_from_url
 
-    if isinstance(output, str) and output.endswith(osp.sep):
+    if isinstance(output, str) and (output.endswith(("/", "\\")) or osp.isdir(output)):
         if not osp.exists(output):
             os.makedirs(output)
         output = osp.join(output, filename_from_url)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,11 +1,15 @@
 import os
-import tempfile
-from collections.abc import Iterator
+from pathlib import Path
+from typing import Final
 from typing import NamedTuple
 
 import pytest
 
 from gdown.download import download
+
+DOWNLOAD_URL: Final[str] = (
+    "https://raw.githubusercontent.com/wkentaro/gdown/3.1.0/gdown/__init__.py"
+)
 
 
 class DownloadEnv(NamedTuple):
@@ -14,12 +18,11 @@ class DownloadEnv(NamedTuple):
 
 
 @pytest.fixture()
-def download_env() -> Iterator[DownloadEnv]:
-    with tempfile.TemporaryDirectory() as d:
-        yield DownloadEnv(
-            file_path=os.path.join(d, "file"),
-            url="https://raw.githubusercontent.com/wkentaro/gdown/3.1.0/gdown/__init__.py",
-        )
+def download_env(tmp_path: Path) -> DownloadEnv:
+    return DownloadEnv(
+        file_path=str(tmp_path / "file"),
+        url=DOWNLOAD_URL,
+    )
 
 
 def test_download(download_env: DownloadEnv) -> None:
@@ -47,3 +50,29 @@ def test_download_progress(download_env: DownloadEnv) -> None:
     final_current, final_total = reported[-1]
     assert final_total is not None
     assert final_current == os.path.getsize(download_env.file_path)
+
+
+def test_download_output_dir_with_trailing_slash(tmp_path: Path) -> None:
+    output_dir = str(tmp_path / "subdir") + "/"
+    result = download(url=DOWNLOAD_URL, output=output_dir, quiet=True)
+    assert isinstance(result, str)
+    assert Path(result).parent == tmp_path / "subdir"
+    assert Path(result).is_file()
+
+
+def test_download_output_dir_with_trailing_backslash(tmp_path: Path) -> None:
+    output_dir = str(tmp_path / "subdir") + "\\"
+    result = download(url=DOWNLOAD_URL, output=output_dir, quiet=True)
+    assert isinstance(result, str)
+    # On Unix, '\' is a valid filename char, so the dir name includes it.
+    # On Windows, '\' is the path separator, so it behaves like '/'.
+    assert Path(result).is_file()
+
+
+def test_download_output_existing_dir(tmp_path: Path) -> None:
+    output_dir = tmp_path / "existing"
+    output_dir.mkdir()
+    result = download(url=DOWNLOAD_URL, output=str(output_dir), quiet=True)
+    assert isinstance(result, str)
+    assert Path(result).parent == output_dir
+    assert Path(result).is_file()

--- a/tests/test_get_filename_from_response.py
+++ b/tests/test_get_filename_from_response.py
@@ -43,8 +43,17 @@ def test_get_filename_from_response(content_disposition: str, expected: str) -> 
         ("Budget/2024.pdf", "Budget_2024.pdf"),
         ("path\\to\\file.pdf", "path_to_file.pdf"),
         ("a/b\\c.pdf", "a_b_c.pdf"),
+        (" report.pdf ", "report.pdf"),
+        ("  folder name  ", "folder name"),
     ],
-    ids=["no-op", "forward-slash", "backslash", "mixed"],
+    ids=[
+        "no-op",
+        "forward-slash",
+        "backslash",
+        "mixed",
+        "trailing-spaces",
+        "both-spaces",
+    ],
 )
 def test_sanitize_filename(filename: str, expected: str) -> None:
     assert _sanitize_filename(filename=filename) == expected


### PR DESCRIPTION
## Summary

- Strip leading/trailing whitespace from filenames in `_sanitize_filename()` — Google Drive allows folder names with trailing spaces, but Windows cannot create such directories
- Fix cross-platform output directory detection — `output.endswith(osp.sep)` only checked `\` on Windows, missing `/`; now checks both separators and also auto-detects existing directories via `osp.isdir()` (rsync-style: if output is an existing directory, append the basename)

The `osp.isdir()` fix also addresses a silent bug where `shutil.move(tmp, existing_dir)` would move the temp file into the directory with a garbled `.part` name instead of the intended filename.

## Test plan

- [x] Added test cases for whitespace stripping in `test_sanitize_filename`
- [x] `make lint` passes
- [x] `make test` passes (27/27)

Closes #413
Closes #109
Closes #314