### PR TITLE
fix: handle corrupted cookies and widen postprocess type

### DIFF
--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -81,7 +81,7 @@ def cached_download(
     path: str | None = None,
     md5: str | None = None,
     quiet: bool = False,
-    postprocess: Callable[[str], None] | None = None,
+    postprocess: Callable[[str], object] | None = None,
     hash: str | None = None,
     **kwargs: Unpack[_DownloadKwargs],
 ) -> str:

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -9,6 +9,7 @@ import tempfile
 import textwrap
 import time
 import urllib.parse
+import warnings
 from collections.abc import Callable
 from http.cookiejar import MozillaCookieJar
 from typing import BinaryIO
@@ -116,8 +117,14 @@ def _get_session(
     cookies_file = osp.join(home, ".cache/gdown/cookies.txt")
     if use_cookies and osp.exists(cookies_file):
         cookie_jar = MozillaCookieJar(cookies_file)
-        cookie_jar.load()
-        sess.cookies.update(cookie_jar)
+        try:
+            cookie_jar.load()
+            sess.cookies.update(cookie_jar)
+        except OSError as e:
+            warnings.warn(
+                f"Failed to load cookies from {cookies_file}: {e}",
+                stacklevel=2,
+            )
 
     return sess, cookies_file
 


### PR DESCRIPTION
## Summary

- Wrap `MozillaCookieJar.load()` in try/except `OSError` with a warning instead of crashing on corrupted/malformed cookie files
- Widen `postprocess` type from `Callable[[str], None]` to `Callable[[str], object]` since `gdown.extractall` returns `list[str]`, not `None`

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (27/27)
- [x] Type checker (`ty`) passes with widened type

Closes #250