### PR TITLE
fix: append correct extension for Google exports in folder downloads

### DIFF
--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -329,9 +329,16 @@ def download_folder(
                 GoogleDriveFileToDownload(id=id, path=path, local_path=local_path)
             )
         else:
+            # Google-native files (Docs, Sheets, Slides) have no extension
+            # in the folder listing. Pass the directory so download() resolves
+            # the correct filename from the Content-Disposition header.
+            if osp.splitext(local_path)[1]:
+                output = local_path
+            else:
+                output = osp.dirname(local_path) + osp.sep
             local_path = download(
                 url="https://drive.google.com/uc?id=" + id,
-                output=local_path,
+                output=output,
                 quiet=quiet,
                 proxy=proxy,
                 speed=speed,

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -107,3 +107,17 @@ def test_download_resume_skips_existing_file_in_dir(tmp_path: Path) -> None:
     )
     assert resume_result == result
     assert os.path.getmtime(result) == mtime_before
+
+
+def test_download_google_slides_without_extension(tmp_path: Path) -> None:
+    # The file "gdown" in Google Drive is a Google Slides file with no extension
+    # in its filename. When downloading directly, download() resolves the correct
+    # .pptx extension from the Content-Disposition header.
+    output = download(
+        url="https://docs.google.com/presentation/d/1DvsG277pWa4WMssXjD9qYYAdF51y7hVidZ6eklfq480/edit?usp=drive_link",
+        output=str(tmp_path) + os.sep,
+        quiet=True,
+        fuzzy=True,
+    )
+    assert isinstance(output, str)
+    assert output.endswith(".pptx")

--- a/tests/test_download_folder.py
+++ b/tests/test_download_folder.py
@@ -1,5 +1,6 @@
 import os.path as osp
 import tempfile
+from pathlib import Path
 
 from gdown.download_folder import _parse_google_drive_file
 from gdown.download_folder import download_folder
@@ -60,6 +61,20 @@ def test_valid_page() -> None:
     assert actual_children_ids == expected_children_ids
     assert actual_children_names == expected_children_names
     assert actual_children_types == expected_children_types
+
+
+def test_download_folder_google_slides_without_extension(tmp_path: Path) -> None:
+    # The folder contains a Google Slides file named "gdown" with no extension in
+    # Google Drive. Previously, download_folder() passed this extensionless name as
+    # the output path to download(), which saved the file without .pptx extension.
+    # The fix passes the directory instead, letting download() resolve the filename
+    # (including extension) from the Content-Disposition header.
+    url = "https://drive.google.com/drive/folders/12zxlvJtuHFV6awc3AINaNHnfvRttPv0i"
+    files = download_folder(url=url, output=str(tmp_path), quiet=True)
+    assert files is not None
+    assert len(files) == 1
+    assert isinstance(files[0], str)
+    assert files[0].endswith(".pptx")
 
 
 def test_download_folder_dry_run() -> None:


### PR DESCRIPTION
## Summary
- Google-native files (Docs, Sheets, Slides) have no extension in their Drive filename
- `download_folder()` was passing this extensionless name as the `output` path to `download()`, saving files without their export extension (e.g., `gdown` instead of `gdown.pptx`)
- Fix: pass the parent directory instead, so `download()` resolves the filename with extension from the Content-Disposition header — the same mechanism that already works for single-file downloads

## Why
Closes #405 — the original PR had the right idea but used a hardcoded extension whitelist. This approach avoids any mapping by letting `download()` use the filename Google provides in the response.

## Test plan
- [x] Reproduced the bug: `gdown --folder <url>` saved Google Slides file without `.pptx` extension
- [x] Verified fix: file now saved as `gdown.pptx`
- [x] Added test for single-file download of Google Slides without extension
- [x] Added test for folder download of Google Slides without extension
- [x] Full test suite passes (pre-existing failures unrelated)
- [x] `make lint` passes