### PR TITLE
fix: remove redundant resume check in download_folder

### DIFF
--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -329,15 +329,6 @@ def download_folder(
                 GoogleDriveFileToDownload(id=id, path=path, local_path=local_path)
             )
         else:
-            if resume and os.path.isfile(local_path):
-                if not quiet:
-                    print(
-                        f"Skipping already downloaded file {local_path}",
-                        file=sys.stderr,
-                    )
-                files.append(local_path)
-                continue
-
             local_path = download(
                 url="https://drive.google.com/uc?id=" + id,
                 output=local_path,

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -76,3 +76,34 @@ def test_download_output_existing_dir(tmp_path: Path) -> None:
     assert isinstance(result, str)
     assert Path(result).parent == output_dir
     assert Path(result).is_file()
+
+
+def test_download_resume_skips_existing_file(
+    download_env: DownloadEnv, capsys: pytest.CaptureFixture[str]
+) -> None:
+    download(url=download_env.url, output=download_env.file_path, quiet=True)
+    mtime_before = os.path.getmtime(download_env.file_path)
+
+    result = download(
+        url=download_env.url,
+        output=download_env.file_path,
+        quiet=False,
+        resume=True,
+    )
+    assert result == download_env.file_path
+    assert os.path.getmtime(download_env.file_path) == mtime_before
+    assert "Skipping already downloaded file" in capsys.readouterr().err
+
+
+def test_download_resume_skips_existing_file_in_dir(tmp_path: Path) -> None:
+    output_dir = tmp_path / "subdir"
+    output_dir.mkdir()
+    result = download(url=DOWNLOAD_URL, output=str(output_dir), quiet=True)
+    assert isinstance(result, str)
+    mtime_before = os.path.getmtime(result)
+
+    resume_result = download(
+        url=DOWNLOAD_URL, output=str(output_dir), quiet=True, resume=True
+    )
+    assert resume_result == result
+    assert os.path.getmtime(result) == mtime_before


### PR DESCRIPTION
## Summary
- `download()` already handles `resume` by checking `os.path.isfile(output)` after resolving the correct filename from `Content-Disposition`
- The resume check in `download_folder()` was redundant and also broken for Google export files — it checked the extensionless `local_path` (e.g., `gdown`), which never matches the correctly-saved file with extension (e.g., `gdown.pptx`)
- Removing it lets `download()` handle resume consistently for all file types

## Test plan
- [x] Existing tests pass
- [x] Resume behavior delegated to `download()`, which already has coverage for this