### PR TITLE
fix: handle dot-dot and null bytes in filename sanitization

### DIFF
--- a/gdown/download.py
+++ b/gdown/download.py
@@ -71,7 +71,11 @@ def get_url_from_gdrive_confirmation(contents: str) -> str:
 
 
 def _sanitize_filename(filename: str) -> str:
-    return filename.replace("/", "_").replace("\\", "_").strip()
+    filename = filename.replace("\x00", "")
+    filename = filename.replace("/", "_").replace("\\", "_").strip()
+    if filename in ("", ".", ".."):
+        return "_"
+    return filename
 
 
 def _get_filename_from_response(response: requests.Response) -> str | None:

--- a/tests/test_get_filename_from_response.py
+++ b/tests/test_get_filename_from_response.py
@@ -45,6 +45,12 @@ def test_get_filename_from_response(content_disposition: str, expected: str) -> 
         ("a/b\\c.pdf", "a_b_c.pdf"),
         (" report.pdf ", "report.pdf"),
         ("  folder name  ", "folder name"),
+        ("..", "_"),
+        (".", "_"),
+        ("", "_"),
+        ("  ", "_"),
+        ("file\x00name.txt", "filename.txt"),
+        ("../../../etc/passwd", ".._.._.._etc_passwd"),
     ],
     ids=[
         "no-op",
@@ -53,6 +59,12 @@ def test_get_filename_from_response(content_disposition: str, expected: str) -> 
         "mixed",
         "trailing-spaces",
         "both-spaces",
+        "dot-dot",
+        "dot",
+        "empty",
+        "whitespace-only",
+        "null-byte",
+        "path-traversal",
     ],
 )
 def test_sanitize_filename(filename: str, expected: str) -> None:


### PR DESCRIPTION
## Summary

- `_sanitize_filename` previously only replaced `/` and `\` with `_` and stripped whitespace, but didn't handle `..`, `.`, null bytes, or empty strings after stripping
- If the entire sanitized filename resolved to `""`, `"."`, or `".."`, `os.path.join(output_dir, filename)` could traverse up a directory or resolve to the parent directory itself
- Null bytes in filenames can cause truncation or unexpected behavior on some systems

## Changes

- Strip null bytes (`\x00`) from the filename before other sanitization
- After slash replacement and whitespace stripping, replace `""`, `"."`, and `".."` with `"_"`
- Added parametrized test cases for all new edge cases: dot-dot, dot, empty string, whitespace-only, null bytes, and path traversal

## Test plan

- [x] All 18 tests in `tests/test_get_filename_from_response.py` pass
- [x] Existing behavior for normal filenames, slashes, and whitespace is preserved