### PR TITLE
fix: validate archive member paths to prevent zip/tar slip

### DIFF
--- a/gdown/extractall.py
+++ b/gdown/extractall.py
@@ -1,6 +1,17 @@
+import os
 import os.path as osp
+import sys
 import tarfile
 import zipfile
+from typing import Literal
+
+_TarReadMode = Literal["r", "r:gz", "r:bz2"]
+
+
+def _is_within_directory(directory: str, target: str) -> bool:
+    abs_directory = osp.realpath(directory)
+    abs_target = osp.realpath(target)
+    return abs_target.startswith(abs_directory + os.sep) or abs_target == abs_directory
 
 
 def extractall(path: str, to: str | None = None) -> list[str]:
@@ -18,10 +29,7 @@ def extractall(path: str, to: str | None = None) -> list[str]:
         to = osp.dirname(path)
 
     if path.endswith(".zip"):
-        with zipfile.ZipFile(path, "r") as f:
-            f.extractall(path=to)
-            names = f.namelist()
-        return [osp.join(to, name) for name in names]
+        return _extractall_zip(path=path, to=to)
 
     if path.endswith(".tar"):
         tar_mode = "r"
@@ -34,8 +42,46 @@ def extractall(path: str, to: str | None = None) -> list[str]:
             f"Could not extract '{path}' as no appropriate extractor is found"
         )
 
-    with tarfile.open(name=path, mode=tar_mode) as f:
+    return _extractall_tar(path=path, to=to, tar_mode=tar_mode)
+
+
+def _extractall_zip(path: str, to: str) -> list[str]:
+    with zipfile.ZipFile(path, "r") as f:
+        names = f.namelist()
+        for member in names:
+            member_path = osp.join(to, member)
+            if not _is_within_directory(directory=to, target=member_path):
+                raise ValueError(
+                    f"Archive member '{member}' would extract outside "
+                    f"target directory: {to}"
+                )
         f.extractall(path=to)
+    return [osp.join(to, name) for name in names]
+
+
+def _extractall_tar(path: str, to: str, tar_mode: _TarReadMode) -> list[str]:
+    with tarfile.open(name=path, mode=tar_mode) as f:
+        if sys.version_info >= (3, 12):
+            f.extractall(path=to, filter="data")
+        else:
+            for member in f.getmembers():
+                if member.issym() or member.islnk():
+                    raise ValueError(
+                        f"Archive member '{member.name}' is a link, "
+                        f"which is not allowed for security reasons"
+                    )
+                if member.ischr() or member.isblk() or member.isfifo():
+                    raise ValueError(
+                        f"Archive member '{member.name}' is a special file, "
+                        f"which is not allowed for security reasons"
+                    )
+                member_path = osp.join(to, member.name)
+                if not _is_within_directory(directory=to, target=member_path):
+                    raise ValueError(
+                        f"Archive member '{member.name}' would extract outside "
+                        f"target directory: {to}"
+                    )
+            f.extractall(path=to)
         names = [m.path for m in f.getmembers()]
 
     return [osp.join(to, name) for name in names]

--- a/tests/test_extractall.py
+++ b/tests/test_extractall.py
@@ -1,0 +1,149 @@
+import io
+import os
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from gdown.extractall import extractall
+
+
+@pytest.fixture
+def _tmp_extract_dir(tmp_path: Path) -> str:
+    d = tmp_path / "extract"
+    d.mkdir()
+    return str(d)
+
+
+def test_zip_normal(tmp_path: Path, _tmp_extract_dir: str) -> None:
+    zip_path = str(tmp_path / "normal.zip")
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("hello.txt", "hello world")
+        zf.writestr("subdir/nested.txt", "nested content")
+
+    result = extractall(path=zip_path, to=_tmp_extract_dir)
+
+    assert os.path.exists(os.path.join(_tmp_extract_dir, "hello.txt"))
+    assert os.path.exists(os.path.join(_tmp_extract_dir, "subdir", "nested.txt"))
+    assert len(result) == 2
+
+
+def test_tar_normal(tmp_path: Path, _tmp_extract_dir: str) -> None:
+    tar_path = str(tmp_path / "normal.tar")
+    with tarfile.open(name=tar_path, mode="w") as tf:
+        data = b"hello world"
+        info = tarfile.TarInfo(name="hello.txt")
+        info.size = len(data)
+        tf.addfile(tarinfo=info, fileobj=io.BytesIO(data))
+
+    result = extractall(path=tar_path, to=_tmp_extract_dir)
+
+    assert os.path.exists(os.path.join(_tmp_extract_dir, "hello.txt"))
+    assert len(result) == 1
+
+
+def test_zip_path_traversal(tmp_path: Path, _tmp_extract_dir: str) -> None:
+    zip_path = str(tmp_path / "evil.zip")
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        info = zipfile.ZipInfo(filename="../evil.txt")
+        zf.writestr(info, "malicious content")
+
+    with pytest.raises(ValueError, match="would extract outside target directory"):
+        extractall(path=zip_path, to=_tmp_extract_dir)
+
+    evil_path = os.path.join(_tmp_extract_dir, "..", "evil.txt")
+    assert not os.path.exists(evil_path)
+
+
+def test_zip_absolute_path(tmp_path: Path, _tmp_extract_dir: str) -> None:
+    zip_path = str(tmp_path / "evil.zip")
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        info = zipfile.ZipInfo(filename="/tmp/evil.txt")
+        zf.writestr(info, "malicious content")
+
+    with pytest.raises(ValueError, match="would extract outside target directory"):
+        extractall(path=zip_path, to=_tmp_extract_dir)
+
+
+def test_tar_absolute_path(tmp_path: Path, _tmp_extract_dir: str) -> None:
+    tar_path = str(tmp_path / "evil.tar")
+    with tarfile.open(name=tar_path, mode="w") as tf:
+        data = b"malicious content"
+        info = tarfile.TarInfo(name="/etc/passwd")
+        info.size = len(data)
+        tf.addfile(tarinfo=info, fileobj=io.BytesIO(data))
+
+    if sys.version_info >= (3, 12):
+        with pytest.raises(tarfile.FilterError):
+            extractall(path=tar_path, to=_tmp_extract_dir)
+    else:
+        with pytest.raises(ValueError, match="would extract outside target directory"):
+            extractall(path=tar_path, to=_tmp_extract_dir)
+
+
+def test_tar_path_traversal(tmp_path: Path, _tmp_extract_dir: str) -> None:
+    tar_path = str(tmp_path / "evil.tar")
+    with tarfile.open(name=tar_path, mode="w") as tf:
+        data = b"malicious content"
+        info = tarfile.TarInfo(name="../evil.txt")
+        info.size = len(data)
+        tf.addfile(tarinfo=info, fileobj=io.BytesIO(data))
+
+    if sys.version_info >= (3, 12):
+        with pytest.raises(tarfile.FilterError):
+            extractall(path=tar_path, to=_tmp_extract_dir)
+    else:
+        with pytest.raises(ValueError, match="would extract outside target directory"):
+            extractall(path=tar_path, to=_tmp_extract_dir)
+
+    evil_path = os.path.join(_tmp_extract_dir, "..", "evil.txt")
+    assert not os.path.exists(evil_path)
+
+
+def test_tar_symlink_rejected(tmp_path: Path, _tmp_extract_dir: str) -> None:
+    tar_path = str(tmp_path / "symlink.tar")
+    with tarfile.open(name=tar_path, mode="w") as tf:
+        info = tarfile.TarInfo(name="evil_link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "/etc/passwd"
+        tf.addfile(tarinfo=info)
+
+    if sys.version_info >= (3, 12):
+        with pytest.raises(tarfile.FilterError):
+            extractall(path=tar_path, to=_tmp_extract_dir)
+    else:
+        with pytest.raises(ValueError, match="is a link"):
+            extractall(path=tar_path, to=_tmp_extract_dir)
+
+
+def test_tar_hardlink_rejected(tmp_path: Path, _tmp_extract_dir: str) -> None:
+    tar_path = str(tmp_path / "hardlink.tar")
+    with tarfile.open(name=tar_path, mode="w") as tf:
+        info = tarfile.TarInfo(name="evil_link")
+        info.type = tarfile.LNKTYPE
+        info.linkname = "/etc/passwd"
+        tf.addfile(tarinfo=info)
+
+    if sys.version_info >= (3, 12):
+        with pytest.raises(tarfile.FilterError):
+            extractall(path=tar_path, to=_tmp_extract_dir)
+    else:
+        with pytest.raises(ValueError, match="is a link"):
+            extractall(path=tar_path, to=_tmp_extract_dir)
+
+
+def test_tar_special_file_rejected(tmp_path: Path, _tmp_extract_dir: str) -> None:
+    tar_path = str(tmp_path / "fifo.tar")
+    with tarfile.open(name=tar_path, mode="w") as tf:
+        info = tarfile.TarInfo(name="evil_fifo")
+        info.type = tarfile.FIFOTYPE
+        tf.addfile(tarinfo=info)
+
+    if sys.version_info >= (3, 12):
+        with pytest.raises(tarfile.FilterError):
+            extractall(path=tar_path, to=_tmp_extract_dir)
+    else:
+        with pytest.raises(ValueError, match="is a special file"):
+            extractall(path=tar_path, to=_tmp_extract_dir)


### PR DESCRIPTION
## Summary

- Fix Zip Slip / Tar Slip vulnerability in `gdown/extractall.py` where archive members with path traversal sequences (e.g., `../evil.txt`) or malicious symlinks could write files outside the target extraction directory.
- Add `_is_within_directory()` helper that validates resolved member paths stay within the target directory.
- For zip extraction: validate all member paths before extracting; raise `ValueError` if any path resolves outside the target directory.
- For tar extraction: use Python 3.12+'s built-in `filter="data"` which prevents path traversal and dangerous symlinks. On Python 3.10-3.11, manually validate member paths and reject symlinks/hardlinks before extracting.

## Approach

The fix uses a dual strategy based on Python version:

- **Python 3.12+**: Uses the `filter="data"` parameter added to `tarfile.extractall()`, which is the officially recommended mitigation. It handles path traversal, symlinks, and other dangerous archive members.
- **Python 3.10-3.11**: Performs manual validation — checks that all resolved member paths stay within the target directory and rejects symlinks/hardlinks entirely.

Zip extraction always uses manual path validation since `zipfile` has no equivalent `filter` parameter.

## Test plan

- [x] Test normal zip extraction still works
- [x] Test normal tar extraction still works
- [x] Test zip with `../evil.txt` member raises `ValueError`
- [x] Test tar with `../evil.txt` member raises appropriate error
- [x] Test tar with symlink pointing outside is rejected