### PR TITLE
fix: sanitize root folder name to prevent path traversal

### DIFF
--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -299,6 +299,8 @@ def download_folder(
         return None
     assert gdrive_file is not None
 
+    gdrive_file.name = _sanitize_filename(filename=gdrive_file.name)
+
     if not quiet:
         print("Retrieving folder contents completed", file=sys.stderr)
         print("Building directory structure", file=sys.stderr)

--- a/tests/test_download_folder.py
+++ b/tests/test_download_folder.py
@@ -1,7 +1,10 @@
 import os.path as osp
+import sys
 import tempfile
+import unittest.mock
 from pathlib import Path
 
+from gdown.download_folder import _GoogleDriveFile
 from gdown.download_folder import _parse_google_drive_file
 from gdown.download_folder import download_folder
 
@@ -75,6 +78,42 @@ def test_download_folder_google_slides_without_extension(tmp_path: Path) -> None
     assert len(files) == 1
     assert isinstance(files[0], str)
     assert files[0].endswith(".pptx")
+
+
+def test_root_folder_name_path_traversal_is_sanitized(tmp_path: Path) -> None:
+    malicious_name = "../../evil"
+    root = _GoogleDriveFile(
+        id="root_id",
+        name=malicious_name,
+        type=_GoogleDriveFile.TYPE_FOLDER,
+        children=[
+            _GoogleDriveFile(
+                id="child_id",
+                name="safe_file.txt",
+                type="text/plain",
+            ),
+        ],
+    )
+
+    output_dir = str(tmp_path) + osp.sep
+
+    with unittest.mock.patch.object(
+        sys.modules["gdown.download_folder"],
+        "_download_and_parse_google_drive_link",
+        return_value=(True, root),
+    ):
+        files = download_folder(
+            url="https://drive.google.com/drive/folders/dummy",
+            output=output_dir,
+            skip_download=True,
+            quiet=True,
+        )
+
+    assert files is not None
+    for file in files:
+        assert not isinstance(file, str)
+        resolved = osp.realpath(file.local_path)
+        assert resolved.startswith(osp.realpath(output_dir))
 
 
 def test_download_folder_dry_run() -> None:


### PR DESCRIPTION
## Summary

- The root folder name parsed from the Google Drive HTML page title was used directly in `os.path.join()` without sanitization, allowing a malicious folder name like `../../evil` to cause path traversal outside the intended output directory.
- Child file/folder names were already sanitized via `_sanitize_filename` in `_get_directory_structure` (line 198), but the root folder name was missed.
- Added `_sanitize_filename()` call on `gdrive_file.name` before `root_dir` construction in `download_folder()`.

## Test plan

- [x] Added `test_root_folder_name_path_traversal_is_sanitized` that creates a `_GoogleDriveFile` with a malicious root name (`../../evil`), sanitizes it, builds directory structure, and verifies all resolved paths stay within the output directory.
- [x] All existing tests pass (`uv run pytest tests/test_download_folder.py -v`).