### PR TITLE
refactor!: remove deprecated md5sum and assert_md5sum

### DIFF
--- a/gdown/__init__.py
+++ b/gdown/__init__.py
@@ -1,10 +1,7 @@
-# flake8: noqa
-
 import importlib.metadata
 
 from . import exceptions
 from .cached_download import cached_download
-from .cached_download import md5sum
 from .download import download
 from .download_folder import download_folder
 from .extractall import extractall

--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -41,41 +41,6 @@ if not osp.exists(cache_root):
         pass
 
 
-def md5sum(filename: str, blocksize: int | None = None) -> str:
-    warnings.warn(
-        "md5sum is deprecated and will be removed in the future.", FutureWarning
-    )
-
-    if blocksize is None:
-        blocksize = 65536
-
-    hash = hashlib.md5()
-    with open(filename, "rb") as f:
-        for block in iter(lambda: f.read(blocksize), b""):
-            hash.update(block)
-    return hash.hexdigest()
-
-
-def assert_md5sum(
-    filename: str, md5: str, quiet: bool = False, blocksize: int | None = None
-) -> bool:
-    warnings.warn(
-        "assert_md5sum is deprecated and will be removed in the future.", FutureWarning
-    )
-
-    if not (isinstance(md5, str) and len(md5) == 32):
-        raise ValueError(f"MD5 must be 32 chars: {md5}")
-
-    md5_actual = md5sum(filename)
-
-    if md5_actual == md5:
-        if not quiet:
-            print(f"MD5 matches: {filename!r} == {md5!r}", file=sys.stderr)
-        return True
-
-    raise AssertionError(f"MD5 doesn't match:\nactual: {md5_actual}\nexpected: {md5}")
-
-
 def cached_download(
     url: str | None = None,
     path: str | None = None,


### PR DESCRIPTION
## Summary

- Remove the deprecated `md5sum` and `assert_md5sum` functions from `gdown/cached_download.py`
- Remove the `from .cached_download import md5sum` re-export from `gdown/__init__.py`
- Remove the vestigial `# flake8: noqa` comment from `gdown/__init__.py`

These functions have had `FutureWarning` deprecation warnings since pre-5.0. The replacements `_compute_filehash` and `_assert_filehash` are already in use throughout the codebase. Removing them as part of the 5.3.0 release preparation.

## Test plan

- [x] `make lint` passes (ruff format, ruff check, ty check, taplo, mdformat, yamlfix, typos)
- [x] Verify no external code depends on `gdown.md5sum` (it was deprecated and undocumented)