### PR TITLE
refactor!: raise DownloadError instead of returning None

### DIFF
--- a/gdown/__init__.py
+++ b/gdown/__init__.py
@@ -4,6 +4,9 @@ from . import exceptions
 from .cached_download import cached_download
 from .download import download
 from .download_folder import download_folder
+from .exceptions import DownloadError
+from .exceptions import FileURLRetrievalError
+from .exceptions import FolderContentsMaximumLimitError
 from .extractall import extractall
 
 __version__ = importlib.metadata.version("gdown")

--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -12,7 +12,7 @@ from . import __version__
 from .download import download
 from .download_folder import MAX_NUMBER_FILES
 from .download_folder import download_folder
-from .exceptions import FileURLRetrievalError
+from .exceptions import DownloadError
 from .exceptions import FolderContentsMaximumLimitError
 
 
@@ -169,9 +169,6 @@ def main() -> None:
                 format=args.format,
                 user_agent=args.user_agent,
             )
-    except FileURLRetrievalError as e:
-        print(e, file=sys.stderr)
-        sys.exit(1)
     except FolderContentsMaximumLimitError as e:
         print(
             "Failed to retrieve folder contents:\n\n{}\n\n"
@@ -180,6 +177,9 @@ def main() -> None:
             ),
             file=sys.stderr,
         )
+        sys.exit(1)
+    except DownloadError as e:
+        print(e, file=sys.stderr)
         sys.exit(1)
     except requests.exceptions.ProxyError as e:
         print(

--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -70,6 +70,14 @@ def cached_download(
     -------
     path:
         Output filename.
+
+    Raises
+    ------
+    ValueError
+        If url is not specified when path is not specified,
+        or if md5 and hash are both specified.
+    DownloadError
+        If the download fails.
     """
     if path is None:
         if url is None:

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -18,6 +18,7 @@ import bs4
 import requests
 import tqdm
 
+from .exceptions import DownloadError
 from .exceptions import FileURLRetrievalError
 from .parse_url import parse_url
 
@@ -148,7 +149,7 @@ def download(
     user_agent: str | None = None,
     log_messages: dict[str, str] | None = None,
     progress: Callable[[int, int | None], None] | None = None,
-) -> str | BinaryIO | None:
+) -> str | BinaryIO:
     """Download file from URL.
 
     Parameters
@@ -332,19 +333,12 @@ def download(
                 existing_tmp_files.append(osp.join(osp.dirname(output), file))
         if resume and existing_tmp_files:
             if len(existing_tmp_files) != 1:
-                print(
-                    "There are multiple temporary files to resume:",
-                    file=sys.stderr,
-                )
-                print("\n")
+                lines = ["There are multiple temporary files to resume:", ""]
                 for file in existing_tmp_files:
-                    print("\t", file, file=sys.stderr)
-                print("\n")
-                print(
-                    "Please remove them except one to resume downloading.",
-                    file=sys.stderr,
-                )
-                return None
+                    lines.append(f"\t{file}")
+                lines.append("")
+                lines.append("Please remove them except one to resume downloading.")
+                raise DownloadError("\n".join(lines))
             tmp_file = existing_tmp_files[0]
         else:
             resume = False

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -199,6 +199,16 @@ def download(
     -------
     output:
         Output filename.
+
+    Raises
+    ------
+    ValueError
+        If neither url nor id is specified, or both are specified.
+    FileURLRetrievalError
+        If the file URL cannot be retrieved from Google Drive.
+    DownloadError
+        If the download fails (e.g., multiple temporary files exist during
+        resume).
     """
     if not (id is None) ^ (url is None):
         raise ValueError("Either url or id has to be specified")

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -330,12 +330,12 @@ def download_folder(
             # in the folder listing. Pass the directory so download() resolves
             # the correct filename from the Content-Disposition header.
             if osp.splitext(local_path)[1]:
-                output = local_path
+                download_output = local_path
             else:
-                output = osp.dirname(local_path) + osp.sep
+                download_output = osp.dirname(local_path) + osp.sep
             local_path = download(
                 url="https://drive.google.com/uc?id=" + id,
-                output=output,
+                output=download_output,
                 quiet=quiet,
                 proxy=proxy,
                 speed=speed,

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -15,6 +15,7 @@ import requests
 from .download import _get_session
 from .download import _sanitize_filename
 from .download import download
+from .exceptions import DownloadError
 from .exceptions import FolderContentsMaximumLimitError
 from .parse_url import is_google_drive_url
 
@@ -111,10 +112,8 @@ def _download_and_parse_google_drive_link(
     quiet: bool = False,
     remaining_ok: bool = False,
     verify: bool | str = True,
-) -> tuple[bool, _GoogleDriveFile | None]:
+) -> _GoogleDriveFile:
     """Get folder structure of Google Drive folder URL."""
-
-    return_code = True
 
     for _ in range(2):
         if is_google_drive_url(url):
@@ -126,7 +125,10 @@ def _download_and_parse_google_drive_link(
 
         res = sess.get(url, verify=verify)
         if res.status_code != 200:
-            return False, None
+            raise DownloadError(
+                f"Failed to retrieve folder contents: {url} "
+                f"(status code {res.status_code})"
+            )
 
         if is_google_drive_url(url):
             break
@@ -165,15 +167,13 @@ def _download_and_parse_google_drive_link(
                 child_id,
                 child_name,
             )
-        return_code, child = _download_and_parse_google_drive_link(
+        child = _download_and_parse_google_drive_link(
             sess=sess,
             url="https://drive.google.com/drive/folders/" + child_id,
             quiet=quiet,
             remaining_ok=remaining_ok,
+            verify=verify,
         )
-        if not return_code:
-            return return_code, None
-        assert child is not None
         gdrive_file.children.append(child)
     has_at_least_max_files = len(gdrive_file.children) == MAX_NUMBER_FILES
     if not remaining_ok and has_at_least_max_files:
@@ -185,7 +185,7 @@ def _download_and_parse_google_drive_link(
             ]
         )
         raise FolderContentsMaximumLimitError(message)
-    return return_code, gdrive_file
+    return gdrive_file
 
 
 def _get_directory_structure(
@@ -223,7 +223,7 @@ def download_folder(
     user_agent: str | None = None,
     skip_download: bool = False,
     resume: bool = False,
-) -> list[str] | list[GoogleDriveFileToDownload] | None:
+) -> list[str] | list[GoogleDriveFileToDownload]:
     """Downloads entire folder from URL.
 
     Parameters
@@ -262,8 +262,7 @@ def download_folder(
     Returns
     -------
     files:
-        If skip_download is False, list of local file paths downloaded
-        or None if failed.
+        If skip_download is False, list of local file paths downloaded.
         If skip_download is True, list of GoogleDriveFileToDownload that contains
         id, path, and local_path.
 
@@ -287,17 +286,13 @@ def download_folder(
 
     if not quiet:
         print("Retrieving folder contents", file=sys.stderr)
-    is_success, gdrive_file = _download_and_parse_google_drive_link(
+    gdrive_file = _download_and_parse_google_drive_link(
         sess,
         url,
         quiet=quiet,
         remaining_ok=remaining_ok,
         verify=verify,
     )
-    if not is_success:
-        print("Failed to retrieve folder contents", file=sys.stderr)
-        return None
-    assert gdrive_file is not None
 
     gdrive_file.name = _sanitize_filename(filename=gdrive_file.name)
 
@@ -348,10 +343,6 @@ def download_folder(
                 verify=verify,
                 resume=resume,
             )
-            if local_path is None:
-                if not quiet:
-                    print("Download ended unsuccessfully", file=sys.stderr)
-                return None
             files.append(local_path)
     if not quiet:
         print("Download completed", file=sys.stderr)

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -266,6 +266,16 @@ def download_folder(
         If skip_download is True, list of GoogleDriveFileToDownload that contains
         id, path, and local_path.
 
+    Raises
+    ------
+    ValueError
+        If neither url nor id is specified, or both are specified.
+    DownloadError
+        If a file in the folder fails to download.
+    FolderContentsMaximumLimitError
+        If the folder has more than MAX_NUMBER_FILES files
+        and remaining_ok is False.
+
     Example
     -------
     gdown.download_folder(

--- a/gdown/exceptions.py
+++ b/gdown/exceptions.py
@@ -1,6 +1,10 @@
-class FileURLRetrievalError(Exception):
+class DownloadError(Exception):
     pass
 
 
-class FolderContentsMaximumLimitError(Exception):
+class FileURLRetrievalError(DownloadError):
+    pass
+
+
+class FolderContentsMaximumLimitError(DownloadError):
     pass

--- a/gdown/extractall.py
+++ b/gdown/extractall.py
@@ -24,6 +24,12 @@ def extractall(path: str, to: str | None = None) -> list[str]:
     to:
         Directory to which the archive file will be extracted.
         If None, it will be set to the parent directory of the archive file.
+
+    Raises
+    ------
+    ValueError
+        If the archive format is unsupported, or if an archive member would
+        extract outside the target directory.
     """
     if to is None:
         to = osp.dirname(path)

--- a/tests/test_download_folder.py
+++ b/tests/test_download_folder.py
@@ -4,9 +4,12 @@ import tempfile
 import unittest.mock
 from pathlib import Path
 
+import pytest
+
 from gdown.download_folder import _GoogleDriveFile
 from gdown.download_folder import _parse_google_drive_file
 from gdown.download_folder import download_folder
+from gdown.exceptions import DownloadError
 
 here = osp.dirname(osp.abspath(__file__))
 
@@ -74,33 +77,36 @@ def test_download_folder_google_slides_without_extension(tmp_path: Path) -> None
     # (including extension) from the Content-Disposition header.
     url = "https://drive.google.com/drive/folders/12zxlvJtuHFV6awc3AINaNHnfvRttPv0i"
     files = download_folder(url=url, output=str(tmp_path), quiet=True)
-    assert files is not None
     assert len(files) == 1
     assert isinstance(files[0], str)
     assert files[0].endswith(".pptx")
 
 
-def test_root_folder_name_path_traversal_is_sanitized(tmp_path: Path) -> None:
-    malicious_name = "../../evil"
-    root = _GoogleDriveFile(
+def _make_folder_root(
+    name: str = "folder", child_name: str = "file.txt"
+) -> _GoogleDriveFile:
+    return _GoogleDriveFile(
         id="root_id",
-        name=malicious_name,
+        name=name,
         type=_GoogleDriveFile.TYPE_FOLDER,
         children=[
             _GoogleDriveFile(
                 id="child_id",
-                name="safe_file.txt",
+                name=child_name,
                 type="text/plain",
             ),
         ],
     )
 
+
+def test_root_folder_name_path_traversal_is_sanitized(tmp_path: Path) -> None:
+    root = _make_folder_root(name="../../evil", child_name="safe_file.txt")
     output_dir = str(tmp_path) + osp.sep
 
     with unittest.mock.patch.object(
         sys.modules["gdown.download_folder"],
         "_download_and_parse_google_drive_link",
-        return_value=(True, root),
+        return_value=root,
     ):
         files = download_folder(
             url="https://drive.google.com/drive/folders/dummy",
@@ -109,18 +115,39 @@ def test_root_folder_name_path_traversal_is_sanitized(tmp_path: Path) -> None:
             quiet=True,
         )
 
-    assert files is not None
     for file in files:
         assert not isinstance(file, str)
         resolved = osp.realpath(file.local_path)
         assert resolved.startswith(osp.realpath(output_dir))
 
 
+def test_download_folder_propagates_download_error(tmp_path: Path) -> None:
+    root = _make_folder_root()
+
+    with (
+        unittest.mock.patch.object(
+            sys.modules["gdown.download_folder"],
+            "_download_and_parse_google_drive_link",
+            return_value=root,
+        ),
+        unittest.mock.patch.object(
+            sys.modules["gdown.download_folder"],
+            "download",
+            side_effect=DownloadError("access denied"),
+        ),
+        pytest.raises(DownloadError, match="access denied"),
+    ):
+        download_folder(
+            url="https://drive.google.com/drive/folders/dummy",
+            output=str(tmp_path) + osp.sep,
+            quiet=True,
+        )
+
+
 def test_download_folder_dry_run() -> None:
     url = "https://drive.google.com/drive/folders/1KpLl_1tcK0eeehzN980zbG-3M2nhbVks"
     tmp_dir = tempfile.mkdtemp()
     files = download_folder(url=url, output=tmp_dir, skip_download=True)
-    assert files is not None
     assert len(files) == 6
     for file in files:
         assert hasattr(file, "id")


### PR DESCRIPTION
## Summary

- Add `DownloadError` base exception class; `FileURLRetrievalError` and `FolderContentsMaximumLimitError` are now subclasses
- `download()` raises `DownloadError` on failure instead of returning `None`
- `download_folder()` raises `DownloadError` on failure instead of returning `None`
- Tighten return types: `download()` returns `str | BinaryIO` (was `str | BinaryIO | None`), `download_folder()` returns `list[str] | list[GoogleDriveFileToDownload]` (was `... | None`)
- Export all exception classes from `gdown.__init__` for easy `except gdown.DownloadError` usage
- Fix pre-existing bug: forward `verify` kwarg in recursive folder content retrieval

Closes #276

## BREAKING CHANGE

`download()` and `download_folder()` now raise `DownloadError` on failure instead of returning `None`. Callers that checked `if result is None` should use `try/except` instead:

```python
# Before (5.x)
result = gdown.download(url=url)
if result is None:
    print("failed")

# After (6.0)
try:
    result = gdown.download(url=url)
except gdown.DownloadError:
    print("failed")
```

## Test plan

- [x] `make lint` passes
- [x] `uv run ty check` passes
- [x] New `test_download_folder_propagates_download_error` verifies exception propagation
- [x] Updated mocks and removed stale `assert files is not None` checks
- [x] All 45 local tests pass