### PR TITLE
refactor: remove redundant type annotations from docstrings

### DIFF
--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -52,23 +52,23 @@ def cached_download(
 
     Parameters
     ----------
-    url: str
+    url:
         URL. Google Drive URL is also supported.
-    path: str, optional
+    path:
         Output filename. Default is basename of URL.
-    quiet: bool
+    quiet:
         Suppress terminal output. Default is False.
-    postprocess: callable, optional
+    postprocess:
         Function called with filename as postprocess.
-    hash: str, optional
+    hash:
         Hash value of file in the format of {algorithm}:{hash_value}
         such as sha256:abcdef.... Supported algorithms: md5, sha1, sha256, sha512.
-    kwargs: dict
+    kwargs:
         Keyword arguments to be passed to `download`.
 
     Returns
     -------
-    path: str
+    path:
         Output filename.
     """
     if path is None:

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -153,50 +153,50 @@ def download(
 
     Parameters
     ----------
-    url: str
+    url:
         URL. Google Drive URL is also supported.
-    output: str
+    output:
         Output filename/directory. Default is basename of URL.
         If output is an existing directory or ends with a path separator,
         the basename will be appended automatically.
-    quiet: bool
+    quiet:
         Suppress terminal output. Default is False.
-    proxy: str
+    proxy:
         Proxy.
-    speed: float
+    speed:
         Download byte size per second (e.g., 256KB/s = 256 * 1024).
-    use_cookies: bool
+    use_cookies:
         Flag to use cookies. Default is True.
-    verify: bool or string
+    verify:
         Either a bool, in which case it controls whether the server's TLS
         certificate is verified, or a string, in which case it must be a path
         to a CA bundle to use. Default is True.
-    id: str
+    id:
         Google Drive's file ID.
-    fuzzy: bool
+    fuzzy:
         Fuzzy extraction of Google Drive's file Id. Default is False.
-    resume: bool
+    resume:
         Resume interrupted downloads while skipping completed ones.
         Default is False.
-    format: str, optional
+    format:
         Format of Google Docs, Spreadsheets and Slides. Default is:
             - Google Docs: 'docx'
             - Google Spreadsheet: 'xlsx'
             - Google Slides: 'pptx'
-    user_agent: str, optional
+    user_agent:
         User-agent to use in the HTTP request.
-    log_messages: dict, optional
+    log_messages:
         Log messages to customize. Currently it supports:
         - 'start': the message to show the start of the download
         - 'output': the message to show the output filename
-    progress: callable, optional
+    progress:
         Callback called after each chunk: ``progress(bytes_so_far, bytes_total)``.
         *bytes_total* is None when Content-Length is unavailable.
         Raise any exception from the callback to abort the download.
 
     Returns
     -------
-    output: str
+    output:
         Output filename.
     """
     if not (id is None) ^ (url is None):

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -228,32 +228,32 @@ def download_folder(
 
     Parameters
     ----------
-    url: str
+    url:
         URL of the Google Drive folder.
         Must be of the format 'https://drive.google.com/drive/folders/{url}'.
-    id: str
+    id:
         Google Drive's folder ID.
-    output: str, optional
+    output:
         String containing the path of the output folder.
         Defaults to current working directory.
-    quiet: bool, optional
+    quiet:
         Suppress terminal output.
-    proxy: str, optional
+    proxy:
         Proxy.
-    speed: float, optional
+    speed:
         Download byte size per second (e.g., 256KB/s = 256 * 1024).
-    use_cookies: bool, optional
+    use_cookies:
         Flag to use cookies. Default is True.
-    verify: bool or string
+    verify:
         Either a bool, in which case it controls whether the server's TLS
         certificate is verified, or a string, in which case it must be a path
         to a CA bundle to use. Default is True.
-    user_agent: str, optional
+    user_agent:
         User-agent to use in the HTTP request.
-    skip_download: bool, optional
+    skip_download:
         If True, return the list of files to download without downloading them.
         Defaults to False.
-    resume: bool
+    resume:
         Resume interrupted transfers.
         Completed output files will be skipped.
         Partial tempfiles will be reused, if the transfer is incomplete.
@@ -261,7 +261,7 @@ def download_folder(
 
     Returns
     -------
-    files: List[str] or List[GoogleDriveFileToDownload] or None
+    files:
         If skip_download is False, list of local file paths downloaded
         or None if failed.
         If skip_download is True, list of GoogleDriveFileToDownload that contains

--- a/gdown/extractall.py
+++ b/gdown/extractall.py
@@ -19,9 +19,9 @@ def extractall(path: str, to: str | None = None) -> list[str]:
 
     Parameters
     ----------
-    path: str
+    path:
         Path of archive file to be extracted.
-    to: str, optional
+    to:
         Directory to which the archive file will be extracted.
         If None, it will be set to the parent directory of the archive file.
     """


### PR DESCRIPTION
## Summary
- Remove redundant type annotations from NumPy-style docstring parameter/return descriptions
- Types are already declared in function signatures via type hints, so duplicating them in docstrings adds maintenance burden without benefit

## Why
The codebase already has full type annotations in function signatures. Repeating types in docstrings (e.g., `url: str` → `url:`) violates DRY and can drift out of sync with the actual signatures.

## Test plan
- [x] No functional code changes — only docstring formatting
- [x] Verified diff is limited to removing type suffixes from parameter lines