### PR TITLE
ci: expand test matrix and split unit/network jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
   unit:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
 jobs:
-  test:
+  unit:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -16,4 +16,12 @@ jobs:
       - uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - run: make test
+      - run: make test PYTEST_ARGS='--numprocesses=auto -m "not network"'
+  network:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: '3.10'
+      - run: make test PYTEST_ARGS='--numprocesses=auto -m network'

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ endif
 PYTEST_ARGS ?= --numprocesses=auto
 
 define exec
-	@uv run --no-sync python -c "print('\033[1;36m$(1)\033[0m')"
+	@uv run --no-sync python -c "import sys;print('\033[1;36m'+' '.join(sys.argv[1:])+'\033[0m')" $(1)
 	@$(1)
 endef
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ source = "vcs"
 content-type = "text/markdown"
 fragments = [{ path = "README.md" }]
 
+[tool.pytest.ini_options]
+markers = ["network: tests that require network access (Google Drive, GitHub)"]
+
 [tool.ruff.lint]
 select = [
   "ANN", # flake8-annotations

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -4,6 +4,8 @@ import subprocess
 import sys
 import tempfile
 
+import pytest
+
 from gdown.cached_download import _assert_filehash
 from gdown.cached_download import _compute_filehash
 
@@ -38,12 +40,14 @@ def _test_cli_with_content(url_or_id: str, content: str) -> None:
             assert f.read() == content
 
 
+@pytest.mark.network
 def test_download_from_url_other_than_gdrive() -> None:
     url = "https://raw.githubusercontent.com/wkentaro/gdown/3.1.0/gdown/__init__.py"
     md5 = "2a51927dde6b146ce56b4d89ebbb5268"
     _test_cli_with_md5(url_or_id=url, md5=md5)
 
 
+@pytest.mark.network
 def test_download_small_file_from_gdrive() -> None:
     with open(os.path.join(here, "data/file_ids.csv")) as f:
         file_ids = [file_id.strip() for file_id in f]
@@ -59,6 +63,7 @@ def test_download_small_file_from_gdrive() -> None:
         raise AssertionError(f"Failed to download any of the files: {file_ids}")
 
 
+@pytest.mark.network
 def test_download_large_file_from_gdrive() -> None:
     with open(os.path.join(here, "data/file_ids_large.csv")) as f:
         file_id_and_md5s = [[x.strip() for x in file_id.split(",")] for file_id in f]
@@ -75,6 +80,7 @@ def test_download_large_file_from_gdrive() -> None:
         raise AssertionError(f"Failed to download any of the files: {file_ids}")
 
 
+@pytest.mark.network
 def test_download_and_extract() -> None:
     cmd = f"gdown --no-cookies {GITHUB_RELEASE_URL} -O - | tar zxvf -"
     with tempfile.TemporaryDirectory() as d:
@@ -82,6 +88,7 @@ def test_download_and_extract() -> None:
         assert os.path.exists(os.path.join(d, "gdown-4.0.0/gdown/__init__.py"))
 
 
+@pytest.mark.network
 def test_download_folder_from_gdrive() -> None:
     with open(os.path.join(here, "data/folder_ids.csv")) as f:
         folder_id_and_md5s = [
@@ -114,6 +121,7 @@ def test_download_folder_from_gdrive() -> None:
         raise AssertionError(f"Failed to download any of the folders: {file_ids}")
 
 
+@pytest.mark.network
 def test_download_a_folder_with_more_than_50_files() -> None:
     url = "https://drive.google.com/drive/folders/1gd3xLkmjT8IckN6WtMbyFZvLR4exRIkn"
 
@@ -139,6 +147,7 @@ def test_download_a_folder_with_more_than_50_files() -> None:
 #     _test_cli_with_md5(url_or_id=file_id, md5=md5, options="--format pdf")
 
 
+@pytest.mark.network
 def test_download_slides_from_gdrive() -> None:
     file_id = "13AhW1Z1GYGaiTpJ0Pr2TTXoQivb6jx-a"
     md5 = "96704c6c40e308a68d3842e83a0136b9"

--- a/tests/test_cached_download.py
+++ b/tests/test_cached_download.py
@@ -1,6 +1,8 @@
 import os
 import tempfile
 
+import pytest
+
 import gdown
 
 
@@ -13,14 +15,17 @@ def _cached_download(hash: str) -> None:
     os.remove(path)
 
 
+@pytest.mark.network
 def test_cached_download_md5() -> None:
     _cached_download(hash="md5:cb31a703b96c1ab2f80d164e9676fe7d")
 
 
+@pytest.mark.network
 def test_cached_download_sha1() -> None:
     _cached_download(hash="sha1:69a5a1000f98237efea9231c8a39d05edf013494")
 
 
+@pytest.mark.network
 def test_cached_download_sha256() -> None:
     _cached_download(
         hash="sha256:284e3029cce3ae5ee0b05866100e300046359f53ae4c77fe6b34c05aa7a72cee"

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -25,6 +25,7 @@ def download_env(tmp_path: Path) -> DownloadEnv:
     )
 
 
+@pytest.mark.network
 def test_download(download_env: DownloadEnv) -> None:
     # Usage before https://github.com/wkentaro/gdown/pull/32
     assert (
@@ -33,6 +34,7 @@ def test_download(download_env: DownloadEnv) -> None:
     )
 
 
+@pytest.mark.network
 def test_download_progress(download_env: DownloadEnv) -> None:
     reported: list[tuple[int, int | None]] = []
     download(
@@ -52,6 +54,7 @@ def test_download_progress(download_env: DownloadEnv) -> None:
     assert final_current == os.path.getsize(download_env.file_path)
 
 
+@pytest.mark.network
 def test_download_output_dir_with_trailing_slash(tmp_path: Path) -> None:
     output_dir = str(tmp_path / "subdir") + "/"
     result = download(url=DOWNLOAD_URL, output=output_dir, quiet=True)
@@ -60,6 +63,7 @@ def test_download_output_dir_with_trailing_slash(tmp_path: Path) -> None:
     assert Path(result).is_file()
 
 
+@pytest.mark.network
 def test_download_output_dir_with_trailing_backslash(tmp_path: Path) -> None:
     output_dir = str(tmp_path / "subdir") + "\\"
     result = download(url=DOWNLOAD_URL, output=output_dir, quiet=True)
@@ -69,6 +73,7 @@ def test_download_output_dir_with_trailing_backslash(tmp_path: Path) -> None:
     assert Path(result).is_file()
 
 
+@pytest.mark.network
 def test_download_output_existing_dir(tmp_path: Path) -> None:
     output_dir = tmp_path / "existing"
     output_dir.mkdir()
@@ -78,6 +83,7 @@ def test_download_output_existing_dir(tmp_path: Path) -> None:
     assert Path(result).is_file()
 
 
+@pytest.mark.network
 def test_download_resume_skips_existing_file(
     download_env: DownloadEnv, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -95,6 +101,7 @@ def test_download_resume_skips_existing_file(
     assert "Skipping already downloaded file" in capsys.readouterr().err
 
 
+@pytest.mark.network
 def test_download_resume_skips_existing_file_in_dir(tmp_path: Path) -> None:
     output_dir = tmp_path / "subdir"
     output_dir.mkdir()
@@ -109,6 +116,7 @@ def test_download_resume_skips_existing_file_in_dir(tmp_path: Path) -> None:
     assert os.path.getmtime(result) == mtime_before
 
 
+@pytest.mark.network
 def test_download_google_slides_without_extension(tmp_path: Path) -> None:
     # The file "gdown" in Google Drive is a Google Slides file with no extension
     # in its filename. When downloading directly, download() resolves the correct

--- a/tests/test_download_folder.py
+++ b/tests/test_download_folder.py
@@ -14,6 +14,7 @@ from gdown.exceptions import DownloadError
 here = osp.dirname(osp.abspath(__file__))
 
 
+@pytest.mark.network
 def test_download_folder_google_slides_without_extension(tmp_path: Path) -> None:
     # The folder contains a Google Slides file named "gdown" with no extension in
     # Google Drive. Previously, download_folder() passed this extensionless name as
@@ -150,6 +151,7 @@ def test_parse_embedded_folder_view_malformed_html() -> None:
         _parse_embedded_folder_view(sess=mock_sess, folder_id="test")
 
 
+@pytest.mark.network
 def test_download_folder_dry_run() -> None:
     url = "https://drive.google.com/drive/folders/1KpLl_1tcK0eeehzN980zbG-3M2nhbVks"
     tmp_dir = tempfile.mkdtemp()

--- a/tests/test_extractall.py
+++ b/tests/test_extractall.py
@@ -68,19 +68,24 @@ def test_zip_absolute_path(tmp_path: Path, _tmp_extract_dir: str) -> None:
 
 
 def test_tar_absolute_path(tmp_path: Path, _tmp_extract_dir: str) -> None:
+    evil_path = str(tmp_path / "outside" / "evil.txt")
     tar_path = str(tmp_path / "evil.tar")
     with tarfile.open(name=tar_path, mode="w") as tf:
         data = b"malicious content"
-        info = tarfile.TarInfo(name="/etc/passwd")
+        info = tarfile.TarInfo(name=evil_path)
         info.size = len(data)
         tf.addfile(tarinfo=info, fileobj=io.BytesIO(data))
 
-    if sys.version_info >= (3, 12):
-        with pytest.raises(tarfile.FilterError):
-            extractall(path=tar_path, to=_tmp_extract_dir)
-    else:
-        with pytest.raises(ValueError, match="would extract outside target directory"):
-            extractall(path=tar_path, to=_tmp_extract_dir)
+    # Python 3.10-3.11: manual _is_within_directory check raises ValueError.
+    # Python 3.12+ Unix: data filter strips the leading '/' and extracts safely.
+    # Python 3.12+ Windows: data filter raises AbsolutePathError (TarError)
+    #   because drive-letter paths (C:\...) remain absolute after stripping.
+    try:
+        extractall(path=tar_path, to=_tmp_extract_dir)
+    except (ValueError, tarfile.TarError):
+        pass
+
+    assert not os.path.exists(evil_path)
 
 
 def test_tar_path_traversal(tmp_path: Path, _tmp_extract_dir: str) -> None:


### PR DESCRIPTION
## Summary

- Split CI test job into **unit** (fast, no network) and **network** (Google Drive/GitHub downloads)
- Unit tests run across the full matrix: 3 OS x 5 Python versions (3.10–3.14)
- Network tests run once on ubuntu/3.10 to avoid redundant downloads and rate-limit flakes
- Fix `test_tar_absolute_path` for Python 3.14 (data filter now strips leading `/` instead of raising)
- Fix Makefile `exec` macro to handle double quotes in `PYTEST_ARGS`

## Test plan

- [x] `make test PYTEST_ARGS='--numprocesses=auto -m "not network"'` passes (34 tests)
- [x] `make test PYTEST_ARGS='--numprocesses=auto -m network'` collects 20 tests
- [x] `make lint` passes