### PR TITLE
refactor!: remove fuzzy option, always extract file ID from Google Drive URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ uv tool install gdown
 gdown https://drive.google.com/uc?id=1l_5RK28JRL19wpT22B-DY9We3TVXnnQQ
 
 # Or copy-paste a share link directly
-gdown --fuzzy 'https://drive.google.com/file/d/0B9P1L--7Wd2vU3VUVlFnbTgtS2c/view?usp=sharing'
+gdown 'https://drive.google.com/file/d/0B9P1L--7Wd2vU3VUVlFnbTgtS2c/view?usp=sharing'
 ```
 
 ## Usage
@@ -62,8 +62,8 @@ gdown https://drive.google.com/uc?id=1l_5RK28JRL19wpT22B-DY9We3TVXnnQQ
 # Download by file ID
 gdown 1l_5RK28JRL19wpT22B-DY9We3TVXnnQQ
 
-# Extract file ID from a share link
-gdown --fuzzy 'https://drive.google.com/file/d/0B9P1L--7Wd2vU3VUVlFnbTgtS2c/view?usp=sharing'
+# Download from a share link
+gdown 'https://drive.google.com/file/d/0B9P1L--7Wd2vU3VUVlFnbTgtS2c/view?usp=sharing'
 
 # Save to a specific path
 gdown https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c -O /tmp/spam.txt
@@ -80,10 +80,10 @@ gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl -
 
 ```bash
 # Download a Google Slides file (default: pptx)
-gdown --fuzzy "https://docs.google.com/presentation/d/15umvZKlsJ3094HNg5S4vJsIhxcFlyTeK/edit?usp=sharing"
+gdown "https://docs.google.com/presentation/d/15umvZKlsJ3094HNg5S4vJsIhxcFlyTeK/edit?usp=sharing"
 
 # Export as PDF instead
-gdown --fuzzy "https://docs.google.com/presentation/d/15umvZKlsJ3094HNg5S4vJsIhxcFlyTeK/edit" --format pdf
+gdown "https://docs.google.com/presentation/d/15umvZKlsJ3094HNg5S4vJsIhxcFlyTeK/edit" --format pdf
 ```
 
 Default export formats: Docs → `docx`, Sheets → `xlsx`, Slides → `pptx`.
@@ -128,6 +128,10 @@ gdown also works with regular URLs, not just Google Drive:
 gdown https://httpbin.org/ip -O ip.json
 ```
 
+> [!NOTE]
+> For Google Drive URLs, gdown automatically extracts the file ID and downloads
+> the actual file. Use curl or wget to download the raw HTML page instead.
+
 ### Python
 
 ```python
@@ -140,9 +144,9 @@ gdown.download(url=url, output="fcn8s_from_caffe.npz")
 # Download by file ID
 gdown.download(id="0B9P1L--7Wd2vNm9zMTJWOGxobkU", output="output.npz")
 
-# Fuzzy extraction from a share link
+# Download from a share link
 url = "https://drive.google.com/file/d/0B9P1L--7Wd2vNm9zMTJWOGxobkU/view?usp=sharing"
-gdown.download(url=url, output="output.npz", fuzzy=True)
+gdown.download(url=url, output="output.npz")
 
 # Download with hash verification and caching
 gdown.cached_download(

--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -70,11 +70,6 @@ def main() -> None:
         help="suppress logging except errors",
     )
     parser.add_argument(
-        "--fuzzy",
-        action="store_true",
-        help="(file only) extract Google Drive's file ID",
-    )
-    parser.add_argument(
         "--proxy",
         help="<protocol://host:port> download using the specified proxy",
     )
@@ -154,7 +149,6 @@ def main() -> None:
                 use_cookies=not args.no_cookies,
                 verify=not args.no_check_certificate,
                 id=id,
-                fuzzy=args.fuzzy,
                 resume=args.continue_,
                 format=args.format,
                 user_agent=args.user_agent,

--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -25,7 +25,6 @@ class _DownloadKwargs(TypedDict, total=False):
     use_cookies: bool
     verify: bool | str
     id: str | None
-    fuzzy: bool
     resume: bool
     format: str | None
     user_agent: str | None

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -143,7 +143,6 @@ def download(
     use_cookies: bool = True,
     verify: bool | str = True,
     id: str | None = None,
-    fuzzy: bool = False,
     resume: bool = False,
     format: str | None = None,
     user_agent: str | None = None,
@@ -174,8 +173,6 @@ def download(
         to a CA bundle to use. Default is True.
     id:
         Google Drive's file ID.
-    fuzzy:
-        Fuzzy extraction of Google Drive's file Id. Default is False.
     resume:
         Resume interrupted downloads while skipping completed ones.
         Default is False.
@@ -229,10 +226,9 @@ def download(
         user_agent=user_agent,
     )
 
-    gdrive_file_id, is_gdrive_download_link = parse_url(url, warning=not fuzzy)
+    gdrive_file_id, is_gdrive_download_link = parse_url(url=url)
 
-    if fuzzy and gdrive_file_id:
-        # overwrite the url with fuzzy match of a file id
+    if gdrive_file_id:
         url = f"https://drive.google.com/uc?id={gdrive_file_id}"
         url_origin = url
         is_gdrive_download_link = True

--- a/gdown/parse_url.py
+++ b/gdown/parse_url.py
@@ -1,6 +1,5 @@
 import re
 import urllib.parse
-import warnings
 
 
 def is_google_drive_url(url: str) -> bool:
@@ -8,7 +7,7 @@ def is_google_drive_url(url: str) -> bool:
     return parsed.hostname in ["drive.google.com", "docs.google.com"]
 
 
-def parse_url(url: str, warning: bool = True) -> tuple[str | None, bool]:
+def parse_url(url: str) -> tuple[str | None, bool]:
     """Parse URLs especially for Google Drive links.
 
     file_id: ID of file on Google Drive.
@@ -43,14 +42,5 @@ def parse_url(url: str, warning: bool = True) -> tuple[str | None, bool]:
             if match:
                 file_id = match.groups()[0]
                 break
-
-    if warning and not is_download_link:
-        warnings.warn(
-            "You specified a Google Drive link that is not the correct link "
-            "to download a file. You might want to try `--fuzzy` option "
-            "or the following url: {url}".format(
-                url=f"https://drive.google.com/uc?id={file_id}"
-            )
-        )
 
     return file_id, is_download_link

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,4 +1,6 @@
 import os
+import sys
+import unittest.mock
 from pathlib import Path
 from typing import Final
 from typing import NamedTuple
@@ -114,6 +116,43 @@ def test_download_resume_skips_existing_file_in_dir(tmp_path: Path) -> None:
     )
     assert resume_result == result
     assert os.path.getmtime(result) == mtime_before
+
+
+@pytest.mark.parametrize(
+    "share_url",
+    [
+        "https://drive.google.com/file/d/0B9P1L--7Wd2vU3VUVlFnbTgtS2c/view?usp=sharing",
+        "https://drive.google.com/open?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c",
+        "https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c",
+    ],
+)
+def test_download_rewrites_google_drive_share_link(
+    tmp_path: Path, share_url: str
+) -> None:
+    expected_url = "https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c"
+
+    mock_response = unittest.mock.Mock()
+    mock_response.status_code = 200
+    mock_response.headers = {
+        "Content-Type": "application/octet-stream",
+        "Content-Disposition": 'attachment; filename="test.bin"',
+    }
+    mock_response.iter_content = lambda chunk_size: [b"data"]
+    mock_response.url = expected_url
+
+    mock_sess = unittest.mock.Mock()
+    mock_sess.get.return_value = mock_response
+    mock_sess.cookies = []
+
+    with unittest.mock.patch.object(
+        sys.modules["gdown.download"],
+        "_get_session",
+        return_value=(mock_sess, str(tmp_path / "cookies.txt")),
+    ):
+        download(url=share_url, output=str(tmp_path / "out"), quiet=True)
+
+        actual_url = mock_sess.get.call_args_list[0].args[0]
+        assert actual_url == expected_url
 
 
 @pytest.mark.network

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -125,7 +125,6 @@ def test_download_google_slides_without_extension(tmp_path: Path) -> None:
         url="https://docs.google.com/presentation/d/1DvsG277pWa4WMssXjD9qYYAdF51y7hVidZ6eklfq480/edit?usp=drive_link",
         output=str(tmp_path) + os.sep,
         quiet=True,
-        fuzzy=True,
     )
     assert isinstance(output, str)
     assert output.endswith(".pptx")

--- a/tests/test_parse_url.py
+++ b/tests/test_parse_url.py
@@ -1,5 +1,3 @@
-import pytest
-
 from gdown.parse_url import parse_url
 
 from .conftest import GITHUB_RELEASE_URL
@@ -12,35 +10,26 @@ def test_parse_url_non_gdrive() -> None:
 def test_parse_url() -> None:
     file_id = "0B_NiLAzvehC9R2stRmQyM3ZiVjQ"
 
-    # list of (url, expected, check_warn)
     urls = [
         (
             f"https://drive.google.com/open?id={file_id}",
             (file_id, False),
-            True,
         ),
         (
             f"https://drive.google.com/uc?id={file_id}",
             (file_id, True),
-            False,
         ),
         (
             f"https://drive.google.com/file/d/{file_id}/view?usp=sharing",
             (file_id, False),
-            True,
         ),
         (
             "https://drive.google.com/a/jsk.imi.i.u-tokyo.ac.jp/uc?id={}&export=download".format(  # NOQA
                 file_id
             ),
             (file_id, True),
-            False,
         ),
     ]
 
-    for url, expected, check_warn in urls:
-        if check_warn:
-            with pytest.warns(UserWarning):
-                assert parse_url(url) == expected
-        else:
-            assert parse_url(url) == expected
+    for url, expected in urls:
+        assert parse_url(url=url) == expected


### PR DESCRIPTION
## Summary
- Remove `--fuzzy` CLI flag and `fuzzy` parameter from `download()` API
- Google Drive file ID extraction is now always-on for all Google Drive URLs
- Remove `warning` parameter from `parse_url()` (no longer needed)
- Remove `fuzzy` from `_DownloadKwargs` TypedDict in `cached_download.py`
- Add note in README about Google Drive URL auto-detection behavior

## Why
The `--fuzzy` flag was a footgun: without it, Google Drive share links would
download the HTML viewer page instead of the actual file. Nobody wants that
behavior. A major version (6.0.0) is the right time to remove the option
entirely and make the correct behavior the default.

## Test plan
- [x] `make lint` passes (ruff, ty, taplo, mdformat, yamlfix, typos)
- [x] `make test` passes (37 unit tests, including 3 new parametrized cases)
- [x] New mocked test verifies URL rewriting for share links, open links, and direct download links
- [x] Manual: `gdown 'https://drive.google.com/file/d/.../view'` downloads the file without `--fuzzy`