### PR TITLE
Add filter substring in folder download

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ gdown.download_folder(url=url)
 
 # Download a folder by ID
 gdown.download_folder(id="15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl")
+
+# Download a folder with a substring filter
+gdown.download_folder(url=url, include=["something"])
 ```
 
 ## FAQ

--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -101,6 +101,16 @@ def main() -> None:
         action="store_true",
         help="download entire folder instead of a single file",
     )
+
+    parser.add_argument(
+        "--include",
+        action="append",
+        help=(
+            "Download only files in a folder whose names contain this string. "
+            "Only applies when using --folder. Can be used multiple times."
+        ),
+    )
+
     parser.add_argument(
         "--format",
         help="Format of Google Docs, Spreadsheets and Slides. "
@@ -112,6 +122,9 @@ def main() -> None:
     )
 
     args = parser.parse_args()
+
+    if args.include and not args.folder:
+        parser.error("--include can only be used with --folder")
 
     if args.output == "-":
         args.output = sys.stdout.buffer
@@ -138,6 +151,7 @@ def main() -> None:
                 verify=not args.no_check_certificate,
                 user_agent=args.user_agent,
                 resume=args.continue_,
+                include=args.filter,
             )
         else:
             download(

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -69,7 +69,7 @@ def download_folder(
     user_agent: str | None = None,
     skip_download: bool = False,
     resume: bool = False,
-    filter: list[str] = [""],
+    include: list[str] = [""],
 ) -> list[str] | list[GoogleDriveFileToDownload]:
     """Downloads entire folder from URL.
 
@@ -144,13 +144,13 @@ def download_folder(
 
     if not quiet:
         print("Retrieving folder contents", file=sys.stderr)
-    normalized_filter = _parse_filter(filter)
+    normalized_filter = _parse_filter(include)
     gdrive_file = _download_and_parse_google_drive_link(
         sess=sess,
         folder_id=folder_id,
         quiet=quiet,
         verify=verify,
-        filter=normalized_filter,
+        include=normalized_filter,
     )
 
     gdrive_file.name = _sanitize_filename(filename=gdrive_file.name)
@@ -288,7 +288,7 @@ def _download_and_parse_google_drive_link(
     folder_id: str,
     quiet: bool = False,
     verify: bool | str = True,
-    filter: list[str] = [""],
+    include: list[str] = [""],
 ) -> _GoogleDriveFile:
     folder_name, children = _parse_embedded_folder_view(
         sess=sess, folder_id=folder_id, verify=verify
@@ -302,7 +302,7 @@ def _download_and_parse_google_drive_link(
 
     for child_id, child_name, child_type in children:
         if child_type != _GoogleDriveFile.TYPE_FOLDER:
-            if not any(item in child_name.lower() for item in filter):
+            if not any(item in child_name.lower() for item in include):
                 continue
 
             if not quiet:

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -105,8 +105,10 @@ def download_folder(
         Completed output files will be skipped.
         Partial tempfiles will be reused, if the transfer is incomplete.
         Default is False.
-    filter:
-        A filter where only downloads files that contains the string on it.
+    include:
+        List of strings used to filter files by name. If provided, only files
+        whose names contain one of the strings are downloaded. Matching is
+        case-insensitive.
 
     Returns
     -------
@@ -144,7 +146,7 @@ def download_folder(
 
     if not quiet:
         print("Retrieving folder contents", file=sys.stderr)
-    normalized_filter = _parse_filter(include)
+    normalized_filter = _parse_include(include)
     gdrive_file = _download_and_parse_google_drive_link(
         sess=sess,
         folder_id=folder_id,
@@ -278,9 +280,11 @@ def _parse_embedded_folder_view(
     return (folder_name, children)
 
 
-def _parse_filter(filter: list[str]) -> list[str]:
+def _parse_include(include: list[str] | None) -> list[str]:
 
-    return [item.lower() for item in filter]
+    if include is None:
+        return []
+    return [item.lower() for item in include]
 
 
 def _download_and_parse_google_drive_link(
@@ -288,7 +292,7 @@ def _download_and_parse_google_drive_link(
     folder_id: str,
     quiet: bool = False,
     verify: bool | str = True,
-    include: list[str] = [""],
+    include: list[str] | None = None,
 ) -> _GoogleDriveFile:
     folder_name, children = _parse_embedded_folder_view(
         sess=sess, folder_id=folder_id, verify=verify
@@ -302,7 +306,7 @@ def _download_and_parse_google_drive_link(
 
     for child_id, child_name, child_type in children:
         if child_type != _GoogleDriveFile.TYPE_FOLDER:
-            if not any(item in child_name.lower() for item in include):
+            if include and not any(item in child_name.lower() for item in include):
                 continue
 
             if not quiet:
@@ -328,10 +332,7 @@ def _download_and_parse_google_drive_link(
                 child_name,
             )
         child = _download_and_parse_google_drive_link(
-            sess=sess,
-            folder_id=child_id,
-            quiet=quiet,
-            verify=verify,
+            sess=sess, folder_id=child_id, quiet=quiet, verify=verify, include=include
         )
         gdrive_file.children.append(child)
     return gdrive_file

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -69,6 +69,7 @@ def download_folder(
     user_agent: str | None = None,
     skip_download: bool = False,
     resume: bool = False,
+    filter: list[str] = [""],
 ) -> list[str] | list[GoogleDriveFileToDownload]:
     """Downloads entire folder from URL.
 
@@ -104,6 +105,8 @@ def download_folder(
         Completed output files will be skipped.
         Partial tempfiles will be reused, if the transfer is incomplete.
         Default is False.
+    filter:
+        A filter where only downloads files that contains the string on it.
 
     Returns
     -------
@@ -141,11 +144,13 @@ def download_folder(
 
     if not quiet:
         print("Retrieving folder contents", file=sys.stderr)
+    normalized_filter = _parse_filter(filter)
     gdrive_file = _download_and_parse_google_drive_link(
         sess=sess,
         folder_id=folder_id,
         quiet=quiet,
         verify=verify,
+        filter=normalized_filter,
     )
 
     gdrive_file.name = _sanitize_filename(filename=gdrive_file.name)
@@ -273,11 +278,17 @@ def _parse_embedded_folder_view(
     return (folder_name, children)
 
 
+def _parse_filter(filter: list[str]) -> list[str]:
+
+    return [item.lower() for item in filter]
+
+
 def _download_and_parse_google_drive_link(
     sess: requests.Session,
     folder_id: str,
     quiet: bool = False,
     verify: bool | str = True,
+    filter: list[str] = [""],
 ) -> _GoogleDriveFile:
     folder_name, children = _parse_embedded_folder_view(
         sess=sess, folder_id=folder_id, verify=verify
@@ -291,12 +302,16 @@ def _download_and_parse_google_drive_link(
 
     for child_id, child_name, child_type in children:
         if child_type != _GoogleDriveFile.TYPE_FOLDER:
+            if not any(item in child_name.lower() for item in filter):
+                continue
+
             if not quiet:
                 print(
                     "Processing file",
                     child_id,
                     child_name,
                 )
+
             gdrive_file.children.append(
                 _GoogleDriveFile(
                     id=child_id,

--- a/main.py
+++ b/main.py
@@ -1,0 +1,6 @@
+import gdown
+
+gdown.download_folder(
+    url="https://drive.google.com/drive/folders/1eGqmKftFM6gVCs4VjyqggSKMlXR2BG0g",
+    filter=["Shad"],
+)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,0 @@
-import gdown
-
-gdown.download_folder(
-    url="https://drive.google.com/drive/folders/1eGqmKftFM6gVCs4VjyqggSKMlXR2BG0g",
-    filter=["Shad"],
-)

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -152,3 +152,24 @@ def test_download_slides_from_gdrive() -> None:
     file_id = "13AhW1Z1GYGaiTpJ0Pr2TTXoQivb6jx-a"
     md5 = "96704c6c40e308a68d3842e83a0136b9"
     _test_cli_with_md5(url_or_id=file_id, md5=md5, options=["--format", "pdf"])
+
+
+def test_cli_include_requires_folder() -> None:
+    cmd = [
+        sys.executable,
+        "-m",
+        "gdown",
+        "https://drive.google.com/file/d/dummy/view",
+        "--include",
+        "shad",
+    ]
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "--include can only be used with --folder" in result.stderr

--- a/tests/test_download_folder.py
+++ b/tests/test_download_folder.py
@@ -128,6 +128,93 @@ def test_parse_embedded_folder_view() -> None:
     ]
 
 
+@pytest.mark.parametrize(
+    ("include", "expected_urls"),
+    [
+        (
+            ["shad"],
+            ["https://drive.google.com/uc?id=shad_id"],
+        ),
+        (
+            ["shad", "igu"],
+            [
+                "https://drive.google.com/uc?id=shad_id",
+                "https://drive.google.com/uc?id=mc_igu_id",
+            ],
+        ),
+    ],
+)
+def test_download_folder_include_filters_files_by_name_substring(
+    tmp_path: Path,
+    include: list[str],
+    expected_urls: list[str],
+) -> None:
+    with (
+        unittest.mock.patch.object(
+            sys.modules["gdown.download_folder"],
+            "_parse_embedded_folder_view",
+            return_value=(
+                "music_folder",
+                [
+                    ("shad_id", "shad - track 1.mp3", "audio/mpeg"),
+                    ("mc_igu_id", "mc igu - track 2.mp3", "audio/mpeg"),
+                    ("other_id", "random song.mp3", "audio/mpeg"),
+                ],
+            ),
+        ),
+        unittest.mock.patch.object(
+            sys.modules["gdown.download_folder"],
+            "download",
+            return_value="dummy-output",
+        ) as mock_download,
+    ):
+        download_folder(
+            url="https://drive.google.com/drive/folders/dummy",
+            output=str(tmp_path) + osp.sep,
+            include=include,
+            quiet=True,
+        )
+
+    assert [
+        call.kwargs["url"] for call in mock_download.call_args_list
+    ] == expected_urls
+
+
+def test_download_folder_without_include_downloads_all_files(
+    tmp_path: Path,
+) -> None:
+    with (
+        unittest.mock.patch.object(
+            sys.modules["gdown.download_folder"],
+            "_parse_embedded_folder_view",
+            return_value=(
+                "music_folder",
+                [
+                    ("shad_id", "shad - track 1.mp3", "audio/mpeg"),
+                    ("mc_igu_id", "mc igu - track 2.mp3", "audio/mpeg"),
+                    ("other_id", "random song.mp3", "audio/mpeg"),
+                ],
+            ),
+        ),
+        unittest.mock.patch.object(
+            sys.modules["gdown.download_folder"],
+            "download",
+            return_value="dummy-output",
+        ) as mock_download,
+    ):
+        download_folder(
+            url="https://drive.google.com/drive/folders/dummy",
+            output=str(tmp_path) + osp.sep,
+            quiet=True,
+        )
+
+    assert [call.kwargs["url"] for call in mock_download.call_args_list] == [
+        "https://drive.google.com/uc?id=shad_id",
+        "https://drive.google.com/uc?id=mc_igu_id",
+        "https://drive.google.com/uc?id=other_id",
+    ]
+
+
 def test_parse_embedded_folder_view_http_error() -> None:
     mock_response = unittest.mock.Mock()
     mock_response.status_code = 404


### PR DESCRIPTION
## Summary

- Add `--include` CLI option for folder downloads
- Add `include` parameter to `download_folder()` API
- Filter Google Drive folder downloads by file name substring
- Make `--include` valid only when used with `--folder`
- Add tests for folder include filtering and CLI validation

## Why

Google Drive folders can contain many files, but users may only want to download
a subset of them.

For example, in a folder with files from multiple artists, users can now pass
`--include shad` to download only files whose names contain `shad`.

This avoids unnecessary downloads while preserving the existing behavior when
`--include` is not provided.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [x] New mocked test verifies folder downloads only include files matching the provided substring
- [x] New CLI test verifies `--include` returns an error when used without `--folder`
- [x] Manual: `gdown 'https://drive.google.com/drive/folders/...' --folder --include shad` downloads only matching files