### PR TITLE
feat: add --json flag to list folder contents as a JSON array

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ gdown https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c -O /tmp/spam.t
 ```bash
 # Download an entire folder
 gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl -O /tmp/folder --folder
+
+# List folder contents as JSON Lines (one object per file: url, name, path)
+gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl --folder --json
+
+# Filter by name and download matches
+gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl --folder --json \
+  | jq -r 'select(.name | test("shad")) | .url' \
+  | xargs -n1 gdown
 ```
 
 #### Google Docs, Sheets, Slides

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ gdown https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c -O /tmp/spam.t
 # Download an entire folder
 gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl -O /tmp/folder --folder
 
-# List folder contents as JSON Lines (one object per file: url, name, path)
+# List folder contents as a JSON array (each entry has url and path)
 gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl --folder --json
 
-# Filter by name and download matches
+# Filter by path and download matches
 gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl --folder --json \
-  | jq -r 'select(.name | test("shad")) | .url' \
+  | jq -r '.[] | select(.path | test("shad")) | .url' \
   | xargs -n1 gdown
 ```
 

--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -107,8 +107,8 @@ def main() -> None:
         "--json",
         action="store_true",
         help=(
-            "list folder contents as JSON Lines on stdout instead of downloading. "
-            "Each line is an object with 'url', 'name', and 'path'. "
+            "list folder contents as a JSON array on stdout instead of "
+            "downloading. Each entry is an object with 'url' and 'path'. "
             "Requires --folder."
         ),
     )
@@ -155,18 +155,16 @@ def main() -> None:
                 skip_download=args.json,
             )
             if args.json:
+                entries = []
                 for file in files:
                     assert isinstance(file, GoogleDriveFileToDownload)
-                    print(
-                        json.dumps(
-                            {
-                                "url": f"https://drive.google.com/uc?id={file.id}",
-                                "name": os.path.basename(file.path),
-                                "path": file.path,
-                            },
-                            ensure_ascii=False,
-                        )
+                    entries.append(
+                        {
+                            "url": f"https://drive.google.com/uc?id={file.id}",
+                            "path": file.path.replace(os.sep, "/"),
+                        }
                     )
+                print(json.dumps(entries, ensure_ascii=False, indent=2))
         else:
             download(
                 url=url,

--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -145,7 +145,7 @@ def main() -> None:
                 url=url,
                 id=id,
                 output=args.output,
-                quiet=args.quiet,
+                quiet=args.quiet or args.json,
                 proxy=args.proxy,
                 speed=args.speed,
                 use_cookies=not args.no_cookies,

--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import os.path
 import re
 import sys
@@ -10,6 +11,7 @@ import requests
 
 from . import __version__
 from .download import download
+from .download_folder import GoogleDriveFileToDownload
 from .download_folder import download_folder
 from .exceptions import DownloadError
 
@@ -102,6 +104,15 @@ def main() -> None:
         help="download entire folder instead of a single file",
     )
     parser.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "list folder contents as JSON Lines on stdout instead of downloading. "
+            "Each line is an object with 'url', 'name', and 'path'. "
+            "Requires --folder."
+        ),
+    )
+    parser.add_argument(
         "--format",
         help="Format of Google Docs, Spreadsheets and Slides. "
         "Default is Google Docs: 'docx', Spreadsheet: 'xlsx', Slides: 'pptx'.",
@@ -112,6 +123,9 @@ def main() -> None:
     )
 
     args = parser.parse_args()
+
+    if args.json and not args.folder:
+        parser.error("--json can only be used with --folder")
 
     if args.output == "-":
         args.output = sys.stdout.buffer
@@ -127,7 +141,7 @@ def main() -> None:
         if args.folder:
             if not (args.output is None or isinstance(args.output, str)):
                 raise ValueError("--folder does not support stdout output (-O -)")
-            download_folder(
+            files = download_folder(
                 url=url,
                 id=id,
                 output=args.output,
@@ -138,7 +152,21 @@ def main() -> None:
                 verify=not args.no_check_certificate,
                 user_agent=args.user_agent,
                 resume=args.continue_,
+                skip_download=args.json,
             )
+            if args.json:
+                for file in files:
+                    assert isinstance(file, GoogleDriveFileToDownload)
+                    print(
+                        json.dumps(
+                            {
+                                "url": f"https://drive.google.com/uc?id={file.id}",
+                                "name": os.path.basename(file.path),
+                                "path": file.path,
+                            },
+                            ensure_ascii=False,
+                        )
+                    )
         else:
             download(
                 url=url,

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -1,13 +1,17 @@
 import hashlib
+import json
 import os
 import subprocess
 import sys
 import tempfile
+import unittest.mock
 
 import pytest
 
+from gdown.__main__ import main
 from gdown.cached_download import _assert_filehash
 from gdown.cached_download import _compute_filehash
+from gdown.download_folder import _GoogleDriveFile
 
 from .conftest import GITHUB_RELEASE_URL
 
@@ -152,3 +156,146 @@ def test_download_slides_from_gdrive() -> None:
     file_id = "13AhW1Z1GYGaiTpJ0Pr2TTXoQivb6jx-a"
     md5 = "96704c6c40e308a68d3842e83a0136b9"
     _test_cli_with_md5(url_or_id=file_id, md5=md5, options=["--format", "pdf"])
+
+
+def test_json_flag_outputs_one_json_line_per_file(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = _GoogleDriveFile(
+        id="root_id",
+        name="myfolder",
+        type=_GoogleDriveFile.TYPE_FOLDER,
+        children=[
+            _GoogleDriveFile(
+                id="child_id",
+                name="track.mp3",
+                type="application/octet-stream",
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "gdown",
+            "https://drive.google.com/drive/folders/dummy",
+            "--folder",
+            "--json",
+        ],
+    )
+    with unittest.mock.patch.object(
+        sys.modules["gdown.download_folder"],
+        "_download_and_parse_google_drive_link",
+        return_value=root,
+    ):
+        main()
+
+    captured = capsys.readouterr()
+    lines = captured.out.strip().splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == {
+        "url": "https://drive.google.com/uc?id=child_id",
+        "name": "track.mp3",
+        "path": "track.mp3",
+    }
+
+
+def test_json_flag_preserves_subfolder_path(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = _GoogleDriveFile(
+        id="root_id",
+        name="myfolder",
+        type=_GoogleDriveFile.TYPE_FOLDER,
+        children=[
+            _GoogleDriveFile(
+                id="sub_id",
+                name="album",
+                type=_GoogleDriveFile.TYPE_FOLDER,
+                children=[
+                    _GoogleDriveFile(
+                        id="nested_id",
+                        name="track.mp3",
+                        type="application/octet-stream",
+                    ),
+                ],
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "gdown",
+            "https://drive.google.com/drive/folders/dummy",
+            "--folder",
+            "--json",
+        ],
+    )
+    with unittest.mock.patch.object(
+        sys.modules["gdown.download_folder"],
+        "_download_and_parse_google_drive_link",
+        return_value=root,
+    ):
+        main()
+
+    captured = capsys.readouterr()
+    lines = captured.out.strip().splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["path"] == os.path.join("album", "track.mp3")
+    assert entry["name"] == "track.mp3"
+    assert entry["url"] == "https://drive.google.com/uc?id=nested_id"
+
+
+def test_json_flag_does_not_download(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = _GoogleDriveFile(
+        id="root_id",
+        name="myfolder",
+        type=_GoogleDriveFile.TYPE_FOLDER,
+        children=[
+            _GoogleDriveFile(
+                id="child_id",
+                name="track.mp3",
+                type="application/octet-stream",
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "gdown",
+            "https://drive.google.com/drive/folders/dummy",
+            "--folder",
+            "--json",
+        ],
+    )
+    with (
+        unittest.mock.patch.object(
+            sys.modules["gdown.download_folder"],
+            "_download_and_parse_google_drive_link",
+            return_value=root,
+        ),
+        unittest.mock.patch.object(
+            sys.modules["gdown.download_folder"], "download"
+        ) as mock_download,
+    ):
+        main()
+
+    mock_download.assert_not_called()
+
+
+def test_json_flag_requires_folder() -> None:
+    cmd = [
+        sys.executable,
+        "-m",
+        "gdown",
+        "https://drive.google.com/file/d/dummy/view",
+        "--json",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    assert result.returncode != 0
+    assert "--json can only be used with --folder" in result.stderr

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -158,7 +158,7 @@ def test_download_slides_from_gdrive() -> None:
     _test_cli_with_md5(url_or_id=file_id, md5=md5, options=["--format", "pdf"])
 
 
-def test_json_flag_outputs_one_json_line_per_file(
+def test_json_flag_outputs_json_array(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     root = _GoogleDriveFile(
@@ -191,13 +191,13 @@ def test_json_flag_outputs_one_json_line_per_file(
         main()
 
     captured = capsys.readouterr()
-    lines = captured.out.strip().splitlines()
-    assert len(lines) == 1
-    assert json.loads(lines[0]) == {
-        "url": "https://drive.google.com/uc?id=child_id",
-        "name": "track.mp3",
-        "path": "track.mp3",
-    }
+    entries = json.loads(captured.out)
+    assert entries == [
+        {
+            "url": "https://drive.google.com/uc?id=child_id",
+            "path": "track.mp3",
+        }
+    ]
 
 
 def test_json_flag_preserves_subfolder_path(
@@ -240,12 +240,13 @@ def test_json_flag_preserves_subfolder_path(
         main()
 
     captured = capsys.readouterr()
-    lines = captured.out.strip().splitlines()
-    assert len(lines) == 1
-    entry = json.loads(lines[0])
-    assert entry["path"] == os.path.join("album", "track.mp3")
-    assert entry["name"] == "track.mp3"
-    assert entry["url"] == "https://drive.google.com/uc?id=nested_id"
+    entries = json.loads(captured.out)
+    assert entries == [
+        {
+            "url": "https://drive.google.com/uc?id=nested_id",
+            "path": "album/track.mp3",
+        }
+    ]
 
 
 def test_json_flag_does_not_download(


### PR DESCRIPTION
Adds `--json` to print folder contents as a JSON array (each entry an object with `url` and `path`) instead of downloading. Lets users filter folders by path with `jq` or `grep` before piping URLs back to gdown. Requires `--folder`.

```bash
$ gdown URL --folder --json | jq -r '.[] | select(.path | test("shad")) | .url' | xargs -n1 gdown
```

Alternative to #458, which baked a substring filter directly into gdown. This decouples filtering from gdown.

Test plan: 4 new tests cover single file, subfolder paths, `--folder` requirement, and the no-download contract; non-network suite (41 tests) passes; lint clean.