### PR TITLE
feat: support --json for single files

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,26 @@
+# gdown
+
+Command-line tool and Python library for downloading files and folders from Google Drive, where direct URL downloads are blocked by interstitial pages (virus-scan confirmation, quota limits).
+
+## Language
+
+**Drive filename**:
+The true name Google Drive holds for a file, carrying its real extension. For a single file it is read from the `Content-Disposition` response header; for a folder it is read from the embedded folder-view HTML. Distinct from the URL basename, which for a Drive download URL is meaningless (e.g. `uc`, `open`).
+_Avoid_: output name, basename
+
+**Listing**:
+The `--json` output: a JSON array of `{url, path}` entries describing what would be downloaded, emitted instead of downloading. A dry run that resolves names without fetching file bodies. Works for both a single file and a folder; takes no output destination (combining with `-O`/`--output`, including `-O -`, is a hard error).
+_Avoid_: manifest, index, dump
+
+**path** (in a Listing entry):
+The location a file would be written to, relative to the download root. For a folder, includes the directory structure. For a single file, it is the bare Drive filename. Always a real Drive filename; never a URL-basename fallback.
+
+**GoogleDriveFileToDownload**:
+The probe result returned by both downloaders under `skip_download=True`: `(id, path, local_path)`. Reused for single files so the probe mode is type-distinct from the normal `str | None` download return, making the mode self-announcing to Python callers and type-checkers.
+
+## Example dialogue
+
+> **Dev:** For a single-file `--json`, what's `path`?
+> **Maintainer:** The Drive filename. Same guarantee as a folder entry: a real name with its real extension, never `uc`.
+> **Dev:** And if there's no `Content-Disposition`, like a non-Drive URL?
+> **Maintainer:** Then there's no Drive filename to report. We error out rather than emit a bad name. The Listing only ever contains real names.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,7 +16,7 @@ _Avoid_: manifest, index, dump
 The location a file would be written to, relative to the download root. For a folder, includes the directory structure. For a single file, it is the bare Drive filename. Always a real Drive filename; never a URL-basename fallback.
 
 **GoogleDriveFileToDownload**:
-The probe result returned by both downloaders under `skip_download=True`: `(id, path, local_path)`. Reused for single files so the probe mode is type-distinct from the normal `str | None` download return, making the mode self-announcing to Python callers and type-checkers.
+The probe result returned by both downloaders under `skip_download=True`: `(id, path, local_path)`. Reused for single files so the probe mode is type-distinct from the normal `str | BinaryIO` download return, making the mode self-announcing to Python callers and type-checkers.
 
 ## Example dialogue
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ gdown 'https://drive.google.com/file/d/0B9P1L--7Wd2vU3VUVlFnbTgtS2c/view?usp=sha
 
 # Save to a specific path
 gdown https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c -O /tmp/spam.txt
+
+# Resolve the filename (with its real extension) without downloading
+gdown https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c --json
+```
+
+The `--json` output is an array of `{url, path}` entries, where `path` is the
+filename Google Drive reports. This lets you choose a name while keeping the
+original extension:
+
+```bash
+url="https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c"
+ext=$(gdown "$url" --json | jq -r '.[0].path | sub(".*\\."; "")')
+gdown "$url" -O "my_name.$ext"
 ```
 
 #### Folders

--- a/docs/adr/0001-single-file-json-returns-file-object.md
+++ b/docs/adr/0001-single-file-json-returns-file-object.md
@@ -15,8 +15,8 @@ backed by `download_folder(skip_download=True)`, which returns
 
 Extending `--json` to single files (GitHub #461) requires a `skip_download`
 mode on `download()`. The open question was what that mode returns. `download()`
-normally returns `str | None` (the output path). Two options for the probe
-result:
+normally returns `str | BinaryIO` (the output path, or the stream for `-O -`).
+Two options for the probe result:
 
 - A bare `str` (the resolved Drive filename).
 - The existing `GoogleDriveFileToDownload` namedtuple `(id, path, local_path)`.
@@ -43,8 +43,8 @@ never derived from a download destination.
 
 ## Consequences
 
-- Probe mode is type-distinct from the normal `str | None` download return, so
-  the mode is self-announcing to readers, callers, and type checkers.
+- Probe mode is type-distinct from the normal `str | BinaryIO` download return,
+  so the mode is self-announcing to readers, callers, and type checkers.
 - The CLI serializes single-file and folder results through one shared block;
   the single-file scalar is wrapped as a one-element list, so `--json` always
   emits a JSON array.
@@ -54,7 +54,6 @@ never derived from a download destination.
 - `local_path` carries no folder-root meaning for a single file; it duplicates
   `path`. Callers inspecting `local_path` to learn a destination get only the
   filename, which is acceptable because `--json` writes nothing.
-- `download()`'s return type widens to
-  `str | BinaryIO | GoogleDriveFileToDownload | None`. As with
-  `download_folder`, the flag-dependent return type is not expressed via
-  `@overload`.
+- `download()`'s return type widens from `str | BinaryIO` to
+  `str | BinaryIO | GoogleDriveFileToDownload`. As with `download_folder`, the
+  flag-dependent return type is not expressed via `@overload`.

--- a/docs/adr/0001-single-file-json-returns-file-object.md
+++ b/docs/adr/0001-single-file-json-returns-file-object.md
@@ -1,0 +1,60 @@
+# 1. Single-file `--json` returns GoogleDriveFileToDownload, not a string
+
+Date: 2026-05-30
+
+## Status
+
+Accepted
+
+## Context
+
+`--json` resolves what would be downloaded and prints it as a JSON array of
+`{url, path}` instead of downloading. It originally worked only for folders,
+backed by `download_folder(skip_download=True)`, which returns
+`list[GoogleDriveFileToDownload]`.
+
+Extending `--json` to single files (GitHub #461) requires a `skip_download`
+mode on `download()`. The open question was what that mode returns. `download()`
+normally returns `str | None` (the output path). Two options for the probe
+result:
+
+- A bare `str` (the resolved Drive filename).
+- The existing `GoogleDriveFileToDownload` namedtuple `(id, path, local_path)`.
+
+A bare `str` is the smaller contract, but it collides with the normal return:
+`download(...)` already returns a path string when downloading. The same type
+would then mean "where I wrote the file" in one mode and "what I would have
+named it" in the other, with nothing at the type level to distinguish them.
+Neither a human reader nor a type checker could tell which mode produced a given
+value.
+
+`GoogleDriveFileToDownload` is already public and already returned by
+`download_folder(skip_download=True)`, so reusing it adds no new public surface.
+It also makes the two `--json` branches return the same element type, so the CLI
+serializes both through one loop.
+
+## Decision
+
+Under `skip_download=True`, `download()` returns a single
+`GoogleDriveFileToDownload`. For a single file there is no folder root, so
+`path` and `local_path` are both the bare Drive filename and `id` is the
+resolved Drive file id. `--json` forbids `-O`/`--output`, so `local_path` is
+never derived from a download destination.
+
+## Consequences
+
+- Probe mode is type-distinct from the normal `str | None` download return, so
+  the mode is self-announcing to readers, callers, and type checkers.
+- The CLI serializes single-file and folder results through one shared block;
+  the single-file scalar is wrapped as a one-element list, so `--json` always
+  emits a JSON array.
+- This is a forward API commitment: Python callers will rely on
+  `download(url, skip_download=True).path`. Changing the single-file probe shape
+  later is a breaking change.
+- `local_path` carries no folder-root meaning for a single file; it duplicates
+  `path`. Callers inspecting `local_path` to learn a destination get only the
+  filename, which is acceptable because `--json` writes nothing.
+- `download()`'s return type widens to
+  `str | BinaryIO | GoogleDriveFileToDownload | None`. As with
+  `download_folder`, the flag-dependent return type is not expressed via
+  `@overload`.

--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -10,8 +10,8 @@ from typing import Any
 import requests
 
 from . import __version__
+from .download import GoogleDriveFileToDownload
 from .download import download
-from .download_folder import GoogleDriveFileToDownload
 from .download_folder import download_folder
 from .exceptions import DownloadError
 
@@ -107,9 +107,9 @@ def main() -> None:
         "--json",
         action="store_true",
         help=(
-            "list folder contents as a JSON array on stdout instead of "
+            "list file or folder contents as a JSON array on stdout instead of "
             "downloading. Each entry is an object with 'url' and 'path'. "
-            "Requires --folder."
+            "Cannot be combined with -O/--output."
         ),
     )
     parser.add_argument(
@@ -124,8 +124,8 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    if args.json and not args.folder:
-        parser.error("--json can only be used with --folder")
+    if args.json and args.output is not None:
+        parser.error("--json cannot be combined with -O/--output")
 
     if args.output == "-":
         args.output = sys.stdout.buffer
@@ -141,7 +141,7 @@ def main() -> None:
         if args.folder:
             if not (args.output is None or isinstance(args.output, str)):
                 raise ValueError("--folder does not support stdout output (-O -)")
-            files = download_folder(
+            result = download_folder(
                 url=url,
                 id=id,
                 output=args.output,
@@ -154,22 +154,11 @@ def main() -> None:
                 resume=args.continue_,
                 skip_download=args.json,
             )
-            if args.json:
-                entries = []
-                for file in files:
-                    assert isinstance(file, GoogleDriveFileToDownload)
-                    entries.append(
-                        {
-                            "url": f"https://drive.google.com/uc?id={file.id}",
-                            "path": file.path.replace(os.sep, "/"),
-                        }
-                    )
-                print(json.dumps(entries, ensure_ascii=False, indent=2))
         else:
-            download(
+            result = download(
                 url=url,
                 output=args.output,
-                quiet=args.quiet,
+                quiet=args.quiet or args.json,
                 proxy=args.proxy,
                 speed=args.speed,
                 use_cookies=not args.no_cookies,
@@ -178,7 +167,21 @@ def main() -> None:
                 resume=args.continue_,
                 format=args.format,
                 user_agent=args.user_agent,
+                skip_download=args.json,
             )
+
+        if args.json:
+            files = result if args.folder else [result]
+            entries = []
+            for file in files:
+                assert isinstance(file, GoogleDriveFileToDownload)
+                entries.append(
+                    {
+                        "url": f"https://drive.google.com/uc?id={file.id}",
+                        "path": file.path.replace(os.sep, "/"),
+                    }
+                )
+            print(json.dumps(entries, ensure_ascii=False, indent=2))
     except DownloadError as e:
         print(e, file=sys.stderr)
         sys.exit(1)

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -153,7 +153,8 @@ def download(
     user_agent: str | None = None,
     log_messages: dict[str, str] | None = None,
     progress: Callable[[int, int | None], None] | None = None,
-) -> str | BinaryIO:
+    skip_download: bool = False,
+) -> str | BinaryIO | GoogleDriveFileToDownload:
     """Download file from URL.
 
     Parameters
@@ -196,18 +197,24 @@ def download(
         Callback called after each chunk: ``progress(bytes_so_far, bytes_total)``.
         *bytes_total* is None when Content-Length is unavailable.
         Raise any exception from the callback to abort the download.
+    skip_download:
+        Resolve the Google Drive filename without downloading the file body.
+        Default is False.
 
     Returns
     -------
     output:
-        Output filename.
+        Output filename when downloading. When skip_download is True, a
+        GoogleDriveFileToDownload whose path is the resolved Google Drive
+        filename.
 
     Raises
     ------
     ValueError
         If neither url nor id is specified, or both are specified.
     FileURLRetrievalError
-        If the file URL cannot be retrieved from Google Drive.
+        If the file URL cannot be retrieved from Google Drive, or if
+        skip_download is True and no Google Drive filename can be resolved.
     DownloadError
         If the download fails (e.g., multiple temporary files exist during
         resume).
@@ -321,6 +328,17 @@ def download(
     if gdrive_file_id and is_gdrive_download_link:
         filename_from_url = _get_filename_from_response(response=res)
         last_modified_time = _get_modified_time_from_response(response=res)
+
+    if skip_download:
+        if filename_from_url is None:
+            raise FileURLRetrievalError(
+                "Could not determine the Google Drive filename; --json requires "
+                f"a resolvable Google Drive file (got: {url_origin})"
+            )
+        return GoogleDriveFileToDownload(
+            id=gdrive_file_id, path=filename_from_url, local_path=filename_from_url
+        )
+
     if filename_from_url is None:
         filename_from_url = _sanitize_filename(filename=osp.basename(url))
 

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -1,3 +1,4 @@
+import collections
 import datetime
 import email.utils
 import os
@@ -24,6 +25,10 @@ from .parse_url import parse_url
 
 CHUNK_SIZE = 512 * 1024  # 512KB
 home = osp.expanduser("~")
+
+GoogleDriveFileToDownload = collections.namedtuple(
+    "GoogleDriveFileToDownload", ("id", "path", "local_path")
+)
 
 
 def get_url_from_gdrive_confirmation(contents: str) -> str:

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import collections
 import os
 import os.path as osp
 import re
@@ -10,6 +9,7 @@ import urllib.parse
 import bs4
 import requests
 
+from .download import GoogleDriveFileToDownload
 from .download import _get_session
 from .download import _sanitize_filename
 from .download import download
@@ -50,11 +50,6 @@ def _get_directory_structure(
         elif not file.children:
             directory_structure.append((file.id, osp.join(previous_path, file.name)))
     return directory_structure
-
-
-GoogleDriveFileToDownload = collections.namedtuple(
-    "GoogleDriveFileToDownload", ("id", "path", "local_path")
-)
 
 
 def download_folder(

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -289,14 +289,85 @@ def test_json_flag_does_not_download(
     mock_download.assert_not_called()
 
 
-def test_json_flag_requires_folder() -> None:
+@pytest.mark.parametrize("output", ["out.bin", "-"])
+def test_json_flag_rejects_output(output: str) -> None:
     cmd = [
         sys.executable,
         "-m",
         "gdown",
         "https://drive.google.com/file/d/dummy/view",
         "--json",
+        "-O",
+        output,
     ]
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     assert result.returncode != 0
-    assert "--json can only be used with --folder" in result.stderr
+    assert "--json cannot be combined with -O/--output" in result.stderr
+
+
+def _fake_session_returning(headers: dict[str, str]) -> unittest.mock.Mock:
+    response = unittest.mock.Mock()
+    response.status_code = 200
+    response.url = "https://drive.google.com/uc?id=child_id"
+    response.headers = headers
+
+    sess = unittest.mock.Mock()
+    sess.get.return_value = response
+    return sess
+
+
+def test_json_flag_single_file_outputs_array(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "gdown",
+            "--no-cookies",
+            "https://drive.google.com/file/d/child_id/view",
+            "--json",
+        ],
+    )
+    sess = _fake_session_returning(
+        {
+            "Content-Type": "application/octet-stream",
+            "Content-Disposition": 'attachment; filename="video.webm"',
+        }
+    )
+    with unittest.mock.patch.object(
+        sys.modules["gdown.download"], "_get_session", return_value=(sess, "")
+    ):
+        main()
+
+    captured = capsys.readouterr()
+    entries = json.loads(captured.out)
+    assert entries == [
+        {
+            "url": "https://drive.google.com/uc?id=child_id",
+            "path": "video.webm",
+        }
+    ]
+
+
+def test_json_flag_single_file_without_drive_filename_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "gdown",
+            "--no-cookies",
+            "https://example.com/file",
+            "--json",
+        ],
+    )
+    sess = _fake_session_returning({"Content-Type": "application/octet-stream"})
+    with (
+        unittest.mock.patch.object(
+            sys.modules["gdown.download"], "_get_session", return_value=(sess, "")
+        ),
+        pytest.raises(SystemExit),
+    ):
+        main()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -7,6 +7,7 @@ from typing import NamedTuple
 
 import pytest
 
+from gdown.download import GoogleDriveFileToDownload
 from gdown.download import download
 
 DOWNLOAD_URL: Final[str] = (
@@ -153,6 +154,38 @@ def test_download_rewrites_google_drive_share_link(
 
         actual_url = mock_sess.get.call_args_list[0].args[0]
         assert actual_url == expected_url
+
+
+def test_download_skip_download_returns_file_object(tmp_path: Path) -> None:
+    file_id = "0B9P1L--7Wd2vU3VUVlFnbTgtS2c"
+
+    mock_response = unittest.mock.Mock()
+    mock_response.status_code = 200
+    mock_response.headers = {
+        "Content-Type": "application/octet-stream",
+        "Content-Disposition": 'attachment; filename="spam.txt"',
+    }
+    mock_response.url = f"https://drive.google.com/uc?id={file_id}"
+
+    mock_sess = unittest.mock.Mock()
+    mock_sess.get.return_value = mock_response
+    mock_sess.cookies = []
+
+    with unittest.mock.patch.object(
+        sys.modules["gdown.download"],
+        "_get_session",
+        return_value=(mock_sess, str(tmp_path / "cookies.txt")),
+    ):
+        result = download(
+            url=f"https://drive.google.com/uc?id={file_id}",
+            quiet=True,
+            skip_download=True,
+        )
+
+    assert result == GoogleDriveFileToDownload(
+        id=file_id, path="spam.txt", local_path="spam.txt"
+    )
+    mock_response.iter_content.assert_not_called()
 
 
 @pytest.mark.network


### PR DESCRIPTION
Close https://github.com/wkentaro/gdown/issues/461

## Summary

- `--json` now works for a single file, not just `--folder`. It resolves the Google Drive filename (with its real extension) from the `Content-Disposition` header and prints `[{url, path}]` without downloading the body.
- This answers #461: gdown stays general-purpose (any file type), so instead of guessing extensions like a video-only tool, it exposes the server-reported name and lets the caller decide. The README shows the extension-keeping workflow.
- `download()` gains `skip_download: bool`. When set, it returns a `GoogleDriveFileToDownload` (same public type the folder path already returns) instead of streaming. A distinct type keeps probe mode discriminable from the normal `str | BinaryIO` return; see `docs/adr/0001`.
- `--json` now rejects `-O`/`--output` (including `-O -`) with a hard error, since a metadata probe has no output destination. This tightens the recently-added (unreleased) folder `--json` behavior too.
- When no Drive filename can be resolved (non-Drive URL, or no `Content-Disposition`), it raises `FileURLRetrievalError` rather than emitting a URL-basename fallback, keeping `path` always a real Drive filename.

## Test plan

- [x] tests added: single-file `--json` output, no-filename raises, `-O`/`-O -` rejection (`tests/test___main__.py`)
- [x] `uv run pytest -m "not network"` — 44 passed
- [x] `uv run ruff check` and `uv run ty check` — clean
- [x] live: `gdown <id> --json` → `[{"url": ".../uc?id=...", "path": "spam.txt"}]`; `gdown <id> --json -O x` → exit 2; `gdown <non-drive-url> --json` → `FileURLRetrievalError`