### PR TITLE
feat: mark --json as beta with a suppressible warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ gdown https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c -O /tmp/spam.t
 gdown https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c --json
 ```
 
-The `--json` output is an array of `{url, path}` entries, where `path` is the
-filename Google Drive reports. This lets you choose a name while keeping the
-original extension:
+`--json` is in beta and its output format may change in a future release; pass
+`--quiet` to silence the beta warning in scripts. The output is an array of
+`{url, path}` entries, where `path` is the filename Google Drive reports. This
+lets you choose a name while keeping the original extension:
 
 ```bash
 url="https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c"

--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -107,8 +107,9 @@ def main() -> None:
         "--json",
         action="store_true",
         help=(
-            "list file or folder contents as a JSON array on stdout instead of "
-            "downloading. Each entry is an object with 'url' and 'path'. "
+            "(beta) list file or folder contents as a JSON array on stdout "
+            "instead of downloading. Each entry is an object with 'url' and "
+            "'path'. The output format may change in a future release. "
             "Cannot be combined with -O/--output."
         ),
     )
@@ -126,6 +127,13 @@ def main() -> None:
 
     if args.json and args.output is not None:
         parser.error("--json cannot be combined with -O/--output")
+
+    if args.json and not args.quiet:
+        print(
+            "warning: `--json` is in beta and its output format may change in a "
+            "future release",
+            file=sys.stderr,
+        )
 
     if args.output == "-":
         args.output = sys.stdout.buffer


### PR DESCRIPTION
Mark `--json` as beta so its output format can change in a future release without being treated as a breaking change. Following uv's preview-feature convention.

## Summary
- Print a one-line `warning: ...` to **stderr** when `--json` is used, so piping the JSON on stdout to `jq` stays clean
- Suppress the warning with `--quiet`, for scripts and pipelines that already silence noise
- Label the flag `(beta)` in `--help` and note the format instability in the README

## Test plan
- [x] `uv run gdown <folder> --folder --json` shows the warning on stderr; stdout stays valid JSON
- [x] `--quiet` suppresses the warning
- [x] `uv run pytest tests/test___main__.py -k json`
- [x] `uv run ruff check` / `ruff format --check`
