### PR TITLE
test: cover docs.google.com and user-indexed URL patterns in parse_url

### DIFF
--- a/tests/test_parse_url.py
+++ b/tests/test_parse_url.py
@@ -29,6 +29,34 @@ def test_parse_url() -> None:
             ),
             (file_id, True),
         ),
+        (
+            f"https://drive.google.com/file/u/0/d/{file_id}/view?usp=sharing",
+            (file_id, False),
+        ),
+        (
+            f"https://docs.google.com/document/d/{file_id}/edit",
+            (file_id, False),
+        ),
+        (
+            f"https://docs.google.com/document/u/0/d/{file_id}/edit",
+            (file_id, False),
+        ),
+        (
+            f"https://docs.google.com/spreadsheets/d/{file_id}/edit",
+            (file_id, False),
+        ),
+        (
+            f"https://docs.google.com/spreadsheets/u/0/d/{file_id}/edit",
+            (file_id, False),
+        ),
+        (
+            f"https://docs.google.com/presentation/d/{file_id}/edit",
+            (file_id, False),
+        ),
+        (
+            f"https://docs.google.com/presentation/u/0/d/{file_id}/htmlview",
+            (file_id, False),
+        ),
     ]
 
     for url, expected in urls:


### PR DESCRIPTION
`parse_url`'s regex table handles eight Google Drive URL forms, but the test
only exercised four: the `?id=` query, `/uc?id=`, `/file/d/.../view`, and the
legacy `/a/<domain>/uc` form. The four `docs.google.com` forms
(document/spreadsheet/presentation) and every `/u/<n>/` user-indexed variant
were never verified, so a regression in those branches would pass CI silently.

This adds the missing cases so all eight regex patterns are exercised, including
the `htmlview` suffix. Source is unchanged.

## Test plan
- [x] `uv run pytest tests/test_parse_url.py`