### PR TITLE
refactor: drop unused quiet arg from _assert_filehash

### DIFF
--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -95,7 +95,7 @@ def cached_download(
         return path
     elif osp.exists(path) and hash:
         try:
-            _assert_filehash(path=path, hash=hash, quiet=quiet)
+            _assert_filehash(path=path, hash=hash)
             return path
         except AssertionError as e:
             print(e, file=sys.stderr)
@@ -122,7 +122,7 @@ def cached_download(
             **kwargs,
         )
         if hash:
-            _assert_filehash(path=temp_path, hash=hash, quiet=quiet)
+            _assert_filehash(path=temp_path, hash=hash)
         with filelock.FileLock(lock_path):
             shutil.move(temp_path, path)
     except Exception:
@@ -152,7 +152,7 @@ def _compute_filehash(path: str, algorithm: str) -> str:
     return f"{algorithm}:{algorithm_instance.hexdigest()}"
 
 
-def _assert_filehash(path: str, hash: str, quiet: bool = False) -> None:
+def _assert_filehash(path: str, hash: str) -> None:
     if ":" not in hash:
         raise ValueError(
             f"Invalid hash: {hash}. "


### PR DESCRIPTION
`_assert_filehash` took a `quiet` parameter that its body never read, and both
internal call sites in `cached_download` threaded `quiet=quiet` into it for no
effect. Dropping the dead parameter and the two pass-throughs.

`cached_download`'s own `quiet` (the user-facing flag) is unchanged. No public
API touched; `_assert_filehash` is private.

## Test plan
- [x] `uv run pytest tests/test_cached_download.py`