### PR TITLE
fix: close pbar and file handle on exception in download() (#472)

### DIFF
--- a/gdown/download.py
+++ b/gdown/download.py
@@ -1,4 +1,5 @@
 import collections
+import contextlib
 import datetime
 import email.utils
 import os
@@ -403,8 +404,11 @@ def download(
             end="",
         )
 
-    pbar = None
-    try:
+    with contextlib.ExitStack() as stack:
+        stack.callback(sess.close)
+        if tmp_file is not None:
+            stack.callback(f.close)
+
         start_size = f.tell() if tmp_file is not None else 0
         if start_size != 0:
             headers = {"Range": f"bytes={start_size}-"}
@@ -415,12 +419,13 @@ def download(
             total = int(total) + start_size
         if not quiet:
             pbar = tqdm.tqdm(total=total, unit="B", initial=start_size, unit_scale=True)
+            stack.callback(pbar.close)
         t_start = time.time()
         downloaded = 0
         for chunk in res.iter_content(chunk_size=CHUNK_SIZE):
             f.write(chunk)
             downloaded += len(chunk)
-            if pbar is not None:
+            if not quiet:
                 pbar.update(len(chunk))
             if progress is not None:
                 progress(downloaded + start_size, total)
@@ -429,16 +434,6 @@ def download(
                 elapsed_time = time.time() - t_start
                 if elapsed_time < elapsed_time_expected:
                     time.sleep(elapsed_time_expected - elapsed_time)
-    finally:
-        try:
-            if pbar is not None:
-                pbar.close()
-        finally:
-            try:
-                if tmp_file is not None and not f.closed:
-                    f.close()
-            finally:
-                sess.close()
 
     if tmp_file is not None:
         assert isinstance(output, str)

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -410,6 +410,7 @@ def download(
             end="",
         )
 
+    pbar = None
     try:
         total = res.headers.get("Content-Length")
         if total is not None:
@@ -440,6 +441,10 @@ def download(
             mtime = last_modified_time.timestamp()
             os.utime(output, (mtime, mtime))
     finally:
+        if pbar is not None:
+            pbar.close()
+        if tmp_file is not None and not f.closed:
+            f.close()
         sess.close()
 
     return output

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -385,35 +385,30 @@ def download(
         tmp_file = None
         f = output
 
+    if not quiet:
+        print(log_messages.get("start", "Downloading...\n"), file=sys.stderr, end="")
+        if resume:
+            print("Resume:", tmp_file, file=sys.stderr)
+        if url_origin != url:
+            print("From (original):", url_origin, file=sys.stderr)
+            print("From (redirected):", url, file=sys.stderr)
+        else:
+            print("From:", url, file=sys.stderr)
+        print(
+            log_messages.get(
+                "output",
+                f"To: {osp.abspath(output) if isinstance(output, str) else output}\n",
+            ),
+            file=sys.stderr,
+            end="",
+        )
+
     pbar = None
     try:
         start_size = f.tell() if tmp_file is not None else 0
         if start_size != 0:
             headers = {"Range": f"bytes={start_size}-"}
             res = sess.get(url, headers=headers, stream=True, verify=verify)
-
-        if not quiet:
-            print(
-                log_messages.get("start", "Downloading...\n"),
-                file=sys.stderr,
-                end="",
-            )
-            if resume:
-                print("Resume:", tmp_file, file=sys.stderr)
-            if url_origin != url:
-                print("From (original):", url_origin, file=sys.stderr)
-                print("From (redirected):", url, file=sys.stderr)
-            else:
-                print("From:", url, file=sys.stderr)
-            output_path = osp.abspath(output) if isinstance(output, str) else output
-            print(
-                log_messages.get(
-                    "output",
-                    f"To: {output_path}\n",
-                ),
-                file=sys.stderr,
-                end="",
-            )
 
         total = res.headers.get("Content-Length")
         if total is not None:

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -385,33 +385,36 @@ def download(
         tmp_file = None
         f = output
 
-    if tmp_file is not None and f.tell() != 0:
-        start_size = f.tell()
-        headers = {"Range": f"bytes={start_size}-"}
-        res = sess.get(url, headers=headers, stream=True, verify=verify)
-    else:
-        start_size = 0
-
-    if not quiet:
-        print(log_messages.get("start", "Downloading...\n"), file=sys.stderr, end="")
-        if resume:
-            print("Resume:", tmp_file, file=sys.stderr)
-        if url_origin != url:
-            print("From (original):", url_origin, file=sys.stderr)
-            print("From (redirected):", url, file=sys.stderr)
-        else:
-            print("From:", url, file=sys.stderr)
-        print(
-            log_messages.get(
-                "output",
-                f"To: {osp.abspath(output) if isinstance(output, str) else output}\n",
-            ),
-            file=sys.stderr,
-            end="",
-        )
-
     pbar = None
     try:
+        start_size = f.tell() if tmp_file is not None else 0
+        if start_size != 0:
+            headers = {"Range": f"bytes={start_size}-"}
+            res = sess.get(url, headers=headers, stream=True, verify=verify)
+
+        if not quiet:
+            print(
+                log_messages.get("start", "Downloading...\n"),
+                file=sys.stderr,
+                end="",
+            )
+            if resume:
+                print("Resume:", tmp_file, file=sys.stderr)
+            if url_origin != url:
+                print("From (original):", url_origin, file=sys.stderr)
+                print("From (redirected):", url, file=sys.stderr)
+            else:
+                print("From:", url, file=sys.stderr)
+            output_path = osp.abspath(output) if isinstance(output, str) else output
+            print(
+                log_messages.get(
+                    "output",
+                    f"To: {output_path}\n",
+                ),
+                file=sys.stderr,
+                end="",
+            )
+
         total = res.headers.get("Content-Length")
         if total is not None:
             total = int(total) + start_size
@@ -422,7 +425,7 @@ def download(
         for chunk in res.iter_content(chunk_size=CHUNK_SIZE):
             f.write(chunk)
             downloaded += len(chunk)
-            if not quiet:
+            if pbar is not None:
                 pbar.update(len(chunk))
             if progress is not None:
                 progress(downloaded + start_size, total)
@@ -431,20 +434,22 @@ def download(
                 elapsed_time = time.time() - t_start
                 if elapsed_time < elapsed_time_expected:
                     time.sleep(elapsed_time_expected - elapsed_time)
-        if not quiet:
-            pbar.close()
-        if tmp_file:
-            f.close()
-            assert isinstance(output, str)
-            shutil.move(tmp_file, output)
-        if isinstance(output, str) and last_modified_time:
-            mtime = last_modified_time.timestamp()
-            os.utime(output, (mtime, mtime))
     finally:
-        if pbar is not None:
-            pbar.close()
-        if tmp_file is not None and not f.closed:
-            f.close()
-        sess.close()
+        try:
+            if pbar is not None:
+                pbar.close()
+        finally:
+            try:
+                if tmp_file is not None and not f.closed:
+                    f.close()
+            finally:
+                sess.close()
+
+    if tmp_file is not None:
+        assert isinstance(output, str)
+        shutil.move(tmp_file, output)
+    if isinstance(output, str) and last_modified_time:
+        mtime = last_modified_time.timestamp()
+        os.utime(output, (mtime, mtime))
 
     return output

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -133,15 +133,17 @@ def download_folder(
         user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"  # NOQA: E501
 
     sess, _ = _get_session(proxy=proxy, use_cookies=use_cookies, user_agent=user_agent)
-
-    if not quiet:
-        print("Retrieving folder contents", file=sys.stderr)
-    gdrive_file = _download_and_parse_google_drive_link(
-        sess=sess,
-        folder_id=folder_id,
-        quiet=quiet,
-        verify=verify,
-    )
+    try:
+        if not quiet:
+            print("Retrieving folder contents", file=sys.stderr)
+        gdrive_file = _download_and_parse_google_drive_link(
+            sess=sess,
+            folder_id=folder_id,
+            quiet=quiet,
+            verify=verify,
+        )
+    finally:
+        sess.close()
 
     gdrive_file.name = _sanitize_filename(filename=gdrive_file.name)
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -47,7 +47,6 @@ def download_session(
 
     session = unittest.mock.Mock()
     session.get.return_value = response
-    session.cookies = []
     monkeypatch.setattr(
         sys.modules["gdown.download"],
         "_get_session",
@@ -205,7 +204,7 @@ def test_download_attempts_all_cleanup_when_closers_raise(
     download_session.close.assert_called_once_with()
 
 
-def test_download_keeps_part_when_pbar_close_raises(
+def test_download_propagates_pbar_close_error_and_keeps_part(
     tmp_path: Path,
     download_session: unittest.mock.Mock,
     opened_files: list[BinaryIO],

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,11 +1,15 @@
+import io
 import os
 import sys
 import unittest.mock
 from pathlib import Path
+from typing import BinaryIO
 from typing import Final
+from typing import Literal
 from typing import NamedTuple
 
 import pytest
+import requests
 
 from gdown.download import GoogleDriveFileToDownload
 from gdown.download import download
@@ -26,6 +30,48 @@ def download_env(tmp_path: Path) -> DownloadEnv:
         file_path=str(tmp_path / "file"),
         url=DOWNLOAD_URL,
     )
+
+
+@pytest.fixture()
+def download_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> unittest.mock.Mock:
+    response = unittest.mock.Mock()
+    response.status_code = 200
+    response.headers = {
+        "Content-Type": "application/octet-stream",
+        "Content-Length": "4",
+    }
+    response.iter_content.return_value = [b"data"]
+    response.url = "https://example.com/file"
+
+    session = unittest.mock.Mock()
+    session.get.return_value = response
+    session.cookies = []
+    monkeypatch.setattr(
+        sys.modules["gdown.download"],
+        "_get_session",
+        lambda **kwargs: (session, "cookies.txt"),
+    )
+    return session
+
+
+@pytest.fixture()
+def opened_files(monkeypatch: pytest.MonkeyPatch) -> list[BinaryIO]:
+    files: list[BinaryIO] = []
+
+    def open_file(path: str, mode: Literal["ab"]) -> BinaryIO:
+        file = open(path, mode)
+        files.append(file)
+        return file
+
+    monkeypatch.setattr(
+        sys.modules["gdown.download"],
+        "open",
+        open_file,
+        raising=False,
+    )
+    return files
 
 
 @pytest.mark.network
@@ -55,6 +101,138 @@ def test_download_progress(download_env: DownloadEnv) -> None:
     final_current, final_total = reported[-1]
     assert final_total is not None
     assert final_current == os.path.getsize(download_env.file_path)
+
+
+def test_download_closes_resources_when_progress_raises(
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,
+    opened_files: list[BinaryIO],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pbar = unittest.mock.Mock()
+    monkeypatch.setattr(
+        sys.modules["gdown.download"].tqdm, "tqdm", lambda **kwargs: pbar
+    )
+
+    with pytest.raises(RuntimeError, match="stop"):
+        download(
+            url="https://example.com/file",
+            output=str(tmp_path / "output"),
+            quiet=False,
+            use_cookies=False,
+            progress=unittest.mock.Mock(side_effect=RuntimeError("stop")),
+        )
+
+    pbar.close.assert_called_once_with()
+    assert opened_files[0].closed
+    download_session.close.assert_called_once_with()
+    part_files = list(tmp_path.glob("output*.part"))
+    assert len(part_files) == 1
+    assert part_files[0].read_bytes() == b"data"
+
+
+def test_download_closes_resources_when_resume_request_raises(
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,
+    opened_files: list[BinaryIO],
+) -> None:
+    download_session.get.side_effect = [
+        download_session.get.return_value,
+        requests.ConnectionError("range request failed"),
+    ]
+    part = tmp_path / "output.partial.part"
+    part.write_bytes(b"partial")
+
+    with pytest.raises(requests.ConnectionError, match="range request failed"):
+        download(
+            url="https://example.com/file",
+            output=str(tmp_path / "output"),
+            quiet=True,
+            use_cookies=False,
+            resume=True,
+        )
+
+    assert opened_files[0].closed
+    download_session.close.assert_called_once_with()
+    assert part.read_bytes() == b"partial"
+
+
+def test_download_keeps_caller_output_open_when_progress_raises(
+    download_session: unittest.mock.Mock,
+) -> None:
+    output = io.BytesIO()
+
+    with pytest.raises(RuntimeError, match="stop"):
+        download(
+            url="https://example.com/file",
+            output=output,
+            quiet=True,
+            use_cookies=False,
+            progress=unittest.mock.Mock(side_effect=RuntimeError("stop")),
+        )
+
+    assert not output.closed
+    assert output.getvalue() == b"data"
+    download_session.close.assert_called_once_with()
+
+
+def test_download_attempts_all_cleanup_when_closers_raise(
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    file = unittest.mock.mock_open()
+    file().closed = False
+    file().tell.return_value = 0
+    file().close.side_effect = OSError("file close failed")
+    pbar = unittest.mock.Mock()
+    pbar.close.side_effect = OSError("pbar close failed")
+    monkeypatch.setattr(sys.modules["gdown.download"], "open", file, raising=False)
+    monkeypatch.setattr(
+        sys.modules["gdown.download"].tqdm, "tqdm", lambda **kwargs: pbar
+    )
+
+    with pytest.raises(OSError, match="file close failed"):
+        download(
+            url="https://example.com/file",
+            output=str(tmp_path / "output"),
+            quiet=False,
+            use_cookies=False,
+            progress=unittest.mock.Mock(side_effect=RuntimeError("stop")),
+        )
+
+    pbar.close.assert_called_once_with()
+    file().close.assert_called_once_with()
+    download_session.close.assert_called_once_with()
+
+
+def test_download_keeps_part_when_pbar_close_raises(
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,
+    opened_files: list[BinaryIO],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "output"
+    pbar = unittest.mock.Mock()
+    pbar.close.side_effect = OSError("pbar close failed")
+    monkeypatch.setattr(
+        sys.modules["gdown.download"].tqdm, "tqdm", lambda **kwargs: pbar
+    )
+
+    with pytest.raises(OSError, match="pbar close failed"):
+        download(
+            url="https://example.com/file",
+            output=str(output),
+            quiet=False,
+            use_cookies=False,
+        )
+
+    assert opened_files[0].closed
+    download_session.close.assert_called_once_with()
+    assert not output.exists()
+    part_files = list(tmp_path.glob("output*.part"))
+    assert len(part_files) == 1
+    assert part_files[0].read_bytes() == b"data"
 
 
 @pytest.mark.network

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -182,7 +182,6 @@ def test_download_attempts_all_cleanup_when_closers_raise(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     file = unittest.mock.mock_open()
-    file().closed = False
     file().tell.return_value = 0
     file().close.side_effect = OSError("file close failed")
     pbar = unittest.mock.Mock()

--- a/tests/test_download_folder.py
+++ b/tests/test_download_folder.py
@@ -90,6 +90,27 @@ def test_download_folder_propagates_download_error(tmp_path: Path) -> None:
         )
 
 
+def test_download_folder_closes_session_when_parsing_raises() -> None:
+    session = unittest.mock.Mock()
+
+    with (
+        unittest.mock.patch.object(
+            sys.modules["gdown.download_folder"],
+            "_get_session",
+            return_value=(session, "cookies.txt"),
+        ),
+        unittest.mock.patch.object(
+            sys.modules["gdown.download_folder"],
+            "_download_and_parse_google_drive_link",
+            side_effect=DownloadError("parse failed"),
+        ),
+        pytest.raises(DownloadError, match="parse failed"),
+    ):
+        download_folder(id="folder_id", quiet=True)
+
+    session.close.assert_called_once_with()
+
+
 def test_parse_embedded_folder_view() -> None:
     html_file = osp.join(here, "data/embedded-folder-view-sample.html")
     with open(html_file) as f:


### PR DESCRIPTION
## Problem

Fixes #472.

Three resources are not released when an exception occurs during download:

| Resource | Location | Leak scenario |
|---|---|---|
| `pbar` (tqdm progress bar) | `download.py` | Any exception while iterating chunks |
| `f` (`.part` file handle) | `download.py` | Same — on Windows: locks the file |
| `sess` (HTTP session) | `download_folder.py` | Exception in `_download_and_parse_google_drive_link` |

The Windows impact for the file handle is observable: a subsequent `download(..., resume=False)` to the same path fails because the process still holds the `.part` file open.

## Root Cause

### `download.py` — `pbar` and `f`

```python
# Both pbar and f are only cleaned up on the happy path:
try:
    ...  # exception here leaves pbar and f open
    if not quiet:
        pbar.close()  # only on happy path
    if tmp_file:
        f.close()     # only on happy path
        shutil.move(tmp_file, output)
finally:
    sess.close()      # only sess is guarded
```

### `download_folder.py` — `sess`

```python
sess, _ = _get_session(...)  # creates session
# no try/finally
gdrive_file = _download_and_parse_google_drive_link(sess=sess, ...)
# if this raises, sess is never closed
```

## Fix

**`download.py`** — initialize `pbar = None` before the `try` block so the `finally` can safely reference it, then add cleanup for both `pbar` and `f`:

```diff
+pbar = None
 try:
     ...
 finally:
+    if pbar is not None:
+        pbar.close()                     # tqdm.close() is idempotent
+    if tmp_file is not None and not f.closed:
+        f.close()                        # only if we own f (not caller BinaryIO)
     sess.close()
```

**`download_folder.py`** — wrap the session-using call in `try/finally`:

```diff
 sess, _ = _get_session(...)
+try:
     gdrive_file = _download_and_parse_google_drive_link(sess=sess, ...)
+finally:
+    sess.close()
```

## Constraints Observed

- `f` is closed **only when `tmp_file is not None`** — when `output` is a caller-provided `BinaryIO`, `f = output` and closing it would be wrong.
- `not f.closed` prevents a double-close on the happy path where `f.close()` already ran inside the `try` body.
- `pbar.close()` is idempotent in tqdm; calling it twice (happy path + finally) is safe.
- The partial `.part` file is left in place (no `shutil.move` on the exception path), so resume keeps working.
