### PR TITLE
feat(cli): add --auto to autodetect file vs. folder downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,14 @@ gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl -
 gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl --folder --json \
   | jq -r '.[] | select(.path | test("shad")) | .url' \
   | xargs -n1 gdown
+
+# Autodetect file vs. folder instead of passing --folder yourself
+gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl --auto
 ```
+
+`--auto` treats a `/drive/folders/` URL as a folder; anything else (a bare ID,
+a file URL) is tried as a file first and retried as a folder only if Drive
+reports it isn't a downloadable file.
 
 #### Google Docs, Sheets, Slides
 

--- a/docs/adr/0002-auto-flag-probes-file-then-retries-as-folder.md
+++ b/docs/adr/0002-auto-flag-probes-file-then-retries-as-folder.md
@@ -1,0 +1,58 @@
+# 2. `--auto` treats folder URLs as folders, retries everything else on `FileURLRetrievalError`
+
+Date: 2026-08-06
+
+## Status
+
+Accepted
+
+## Context
+
+Users must currently pass `--folder` explicitly; a bare ID or non-`/folders/`
+URL that actually points at a folder just fails. `--auto` removes that
+requirement by detecting which mode to use.
+
+A Drive folder URL (`.../drive/folders/<id>`) is unambiguous — no probing
+needed. A bare ID or a `.../file/d/<id>/...`-shaped URL is not: Drive IDs
+don't self-describe their type, and a bare ID is deliberately ambiguous
+(could be either). The only way to know for certain is to ask Drive.
+
+Two ways to ask:
+
+- Fetch Drive metadata for the ID up front (e.g. an explicit "what is this"
+  request) before choosing a code path.
+- Just try file mode; Drive's own response tells us if that was wrong.
+
+`download()` already surfaces "this isn't a downloadable file" as
+`FileURLRetrievalError` — raised when the resolution loop can't find a
+confirmation link, download form, or `downloadUrl` in Drive's response, which
+is exactly what happens when the id/URL is actually a folder. Reusing that
+error instead of adding a separate metadata lookup means `--auto` costs no
+extra request in the common case (first guess is right) and needs no new
+Drive API surface. The error is raised entirely within the URL-resolution
+phase of `download()`, before any file is opened for writing, so a retry
+never needs to clean up a partial download.
+
+## Decision
+
+`--auto`:
+
+- If `url_or_id` is a URL matching `/drive/folders/`, download as a folder
+  directly (same as passing `--folder`).
+- Otherwise, attempt file mode. If `download()` raises `FileURLRetrievalError`,
+  retry the same `url_or_id` as a folder via `download_folder()`.
+- `--auto` and `--folder` are mutually exclusive (`--folder` already commits
+  to a mode; combining is either redundant or contradictory) — hard
+  `argparse` error, matching the existing `--json`/`-O` conflict style.
+
+## Consequences
+
+- No extra Drive request for the common cases (folder URL, or a file ID that
+  really is a file) — detection is free or a natural side effect of the
+  existing resolution flow.
+- A folder ID given as `url_or_id` (not a `/folders/` URL) costs one wasted
+  file-mode round trip before the folder retry. Acceptable: bare IDs are
+  ambiguous by construction, and this is the only case that pays the cost.
+- Other `DownloadError` subclasses are not treated as "maybe a folder" and
+  propagate immediately — only `FileURLRetrievalError` specifically means
+  "not a downloadable file," so only it triggers the retry.

--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -14,6 +14,9 @@ from .download import GoogleDriveFileToDownload
 from .download import download
 from .download_folder import download_folder
 from .exceptions import DownloadError
+from .exceptions import FileURLRetrievalError
+
+_FOLDER_URL_RE = re.compile(r"^https?://drive\.google\.com/drive/(u/[0-9]+/)?folders/")
 
 
 class _ShowVersionAction(argparse.Action):
@@ -104,6 +107,17 @@ def main() -> None:
         help="download entire folder instead of a single file",
     )
     parser.add_argument(
+        "--auto",
+        action="store_true",
+        help=(
+            "autodetect whether to download a file or a folder instead of "
+            "requiring --folder. A '/drive/folders/' URL is treated as a "
+            "folder; anything else is tried as a file first and retried as "
+            "a folder if Drive reports it isn't a downloadable file. "
+            "Cannot be combined with --folder."
+        ),
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help=(
@@ -128,6 +142,9 @@ def main() -> None:
     if args.json and args.output is not None:
         parser.error("--json cannot be combined with -O/--output")
 
+    if args.auto and args.folder:
+        parser.error("--auto cannot be combined with --folder")
+
     if args.json and not args.quiet:
         print(
             "warning: `--json` is in beta and its output format may change in a "
@@ -145,41 +162,55 @@ def main() -> None:
         url = None
         id = args.url_or_id
 
+    as_folder = args.folder
+    if args.auto and url is not None and _FOLDER_URL_RE.match(url):
+        as_folder = True
+
+    def _download_as_folder() -> list[str] | list[GoogleDriveFileToDownload]:
+        if not (args.output is None or isinstance(args.output, str)):
+            raise ValueError("--folder does not support stdout output (-O -)")
+        return download_folder(
+            url=url,
+            id=id,
+            output=args.output,
+            quiet=args.quiet or args.json,
+            proxy=args.proxy,
+            speed=args.speed,
+            use_cookies=not args.no_cookies,
+            verify=not args.no_check_certificate,
+            user_agent=args.user_agent,
+            resume=args.continue_,
+            skip_download=args.json,
+        )
+
     try:
-        if args.folder:
-            if not (args.output is None or isinstance(args.output, str)):
-                raise ValueError("--folder does not support stdout output (-O -)")
-            result = download_folder(
-                url=url,
-                id=id,
-                output=args.output,
-                quiet=args.quiet or args.json,
-                proxy=args.proxy,
-                speed=args.speed,
-                use_cookies=not args.no_cookies,
-                verify=not args.no_check_certificate,
-                user_agent=args.user_agent,
-                resume=args.continue_,
-                skip_download=args.json,
-            )
+        if as_folder:
+            result = _download_as_folder()
         else:
-            result = download(
-                url=url,
-                output=args.output,
-                quiet=args.quiet or args.json,
-                proxy=args.proxy,
-                speed=args.speed,
-                use_cookies=not args.no_cookies,
-                verify=not args.no_check_certificate,
-                id=id,
-                resume=args.continue_,
-                format=args.format,
-                user_agent=args.user_agent,
-                skip_download=args.json,
-            )
+            try:
+                result = download(
+                    url=url,
+                    output=args.output,
+                    quiet=args.quiet or args.json,
+                    proxy=args.proxy,
+                    speed=args.speed,
+                    use_cookies=not args.no_cookies,
+                    verify=not args.no_check_certificate,
+                    id=id,
+                    resume=args.continue_,
+                    format=args.format,
+                    user_agent=args.user_agent,
+                    skip_download=args.json,
+                )
+            except FileURLRetrievalError:
+                if not args.auto:
+                    raise
+                # Not a downloadable file; retry assuming url_or_id is a folder.
+                as_folder = True
+                result = _download_as_folder()
 
         if args.json:
-            files = result if args.folder else [result]
+            files = result if as_folder else [result]
             entries = []
             for file in files:
                 assert isinstance(file, GoogleDriveFileToDownload)

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -13,6 +13,7 @@ from gdown.__main__ import main
 from gdown.cached_download import _assert_filehash
 from gdown.cached_download import _compute_filehash
 from gdown.download_folder import _GoogleDriveFile
+from gdown.exceptions import FileURLRetrievalError
 
 from .conftest import GITHUB_RELEASE_URL
 
@@ -304,6 +305,145 @@ def test_json_flag_rejects_output(output: str) -> None:
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     assert result.returncode != 0
     assert "--json cannot be combined with -O/--output" in result.stderr
+
+
+def test_auto_flag_rejects_folder() -> None:
+    cmd = [
+        sys.executable,
+        "-m",
+        "gdown",
+        "https://drive.google.com/drive/folders/dummy",
+        "--auto",
+        "--folder",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    assert result.returncode != 0
+    assert "--auto cannot be combined with --folder" in result.stderr
+
+
+def test_auto_flag_treats_folder_url_as_folder(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = _GoogleDriveFile(
+        id="root_id",
+        name="myfolder",
+        type=_GoogleDriveFile.TYPE_FOLDER,
+        children=[
+            _GoogleDriveFile(
+                id="child_id",
+                name="track.mp3",
+                type="application/octet-stream",
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "gdown",
+            "https://drive.google.com/drive/folders/dummy",
+            "--auto",
+            "--json",
+        ],
+    )
+    with (
+        unittest.mock.patch.object(
+            sys.modules["gdown.download_folder"],
+            "_download_and_parse_google_drive_link",
+            return_value=root,
+        ),
+        unittest.mock.patch.object(
+            sys.modules["gdown.__main__"], "download"
+        ) as mock_download,
+    ):
+        main()
+
+    mock_download.assert_not_called()
+    captured = capsys.readouterr()
+    entries = json.loads(captured.out)
+    assert entries == [
+        {
+            "url": "https://drive.google.com/uc?id=child_id",
+            "path": "track.mp3",
+        }
+    ]
+
+
+def test_auto_flag_falls_back_to_folder_when_file_retrieval_fails(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = _GoogleDriveFile(
+        id="root_id",
+        name="myfolder",
+        type=_GoogleDriveFile.TYPE_FOLDER,
+        children=[
+            _GoogleDriveFile(
+                id="child_id",
+                name="track.mp3",
+                type="application/octet-stream",
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "gdown",
+            "https://drive.google.com/file/d/dummy/view",
+            "--auto",
+            "--json",
+        ],
+    )
+    with (
+        unittest.mock.patch.object(
+            sys.modules["gdown.__main__"],
+            "download",
+            side_effect=FileURLRetrievalError("not a downloadable file"),
+        ),
+        unittest.mock.patch.object(
+            sys.modules["gdown.download_folder"],
+            "_download_and_parse_google_drive_link",
+            return_value=root,
+        ),
+    ):
+        main()
+
+    captured = capsys.readouterr()
+    entries = json.loads(captured.out)
+    assert entries == [
+        {
+            "url": "https://drive.google.com/uc?id=child_id",
+            "path": "track.mp3",
+        }
+    ]
+
+
+def test_without_auto_flag_file_retrieval_error_is_not_retried_as_folder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "gdown",
+            "https://drive.google.com/file/d/dummy/view",
+            "--json",
+        ],
+    )
+    with (
+        unittest.mock.patch.object(
+            sys.modules["gdown.__main__"],
+            "download",
+            side_effect=FileURLRetrievalError("not a downloadable file"),
+        ),
+        unittest.mock.patch.object(
+            sys.modules["gdown.download_folder"], "download_folder"
+        ) as mock_download_folder,
+        pytest.raises(SystemExit),
+    ):
+        main()
+
+    mock_download_folder.assert_not_called()
 
 
 def _fake_session_returning(headers: dict[str, str]) -> unittest.mock.Mock:


### PR DESCRIPTION
`--auto` treats a /drive/folders/ URL as a folder directly; anything else is tried as a file first and retried as a folder only if Drive's response indicates it isn't a downloadable file (FileURLRetrievalError). Mutually exclusive with `--folder`. See ADR 0002.