### PR TITLE
fix: fail when a download body ends before the announced size

### DIFF
--- a/changelog.d/481.fixed.md
+++ b/changelog.d/481.fixed.md
@@ -1,0 +1,1 @@
+Reject incomplete response bodies instead of saving them as completed downloads.

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -101,6 +101,31 @@ def _get_filename_from_response(*, response: requests.Response) -> str | None:
     return None
 
 
+def _get_content_length_from_response(*, response: requests.Response) -> int | None:
+    content_length = response.headers.get("Content-Length")
+    if content_length is None:
+        return None
+    try:
+        size = int(content_length)
+    except ValueError:
+        return None
+    return size if size >= 0 else None
+
+
+def _has_only_identity_encoding(*, response: requests.Response, header: str) -> bool:
+    encodings = response.headers.get(header, "").split(",")
+    return all(encoding.strip().lower() in ("", "identity") for encoding in encodings)
+
+
+def _is_content_length_comparable(*, response: requests.Response) -> bool:
+    # A content encoding the client decodes transparently makes Content-Length
+    # count the encoded bytes on the wire instead of the ones iteration yields,
+    # and a transfer encoding makes the client ignore Content-Length entirely.
+    return _has_only_identity_encoding(
+        response=response, header="Content-Encoding"
+    ) and _has_only_identity_encoding(response=response, header="Transfer-Encoding")
+
+
 def _get_modified_time_from_response(
     *,
     response: requests.Response,
@@ -222,7 +247,8 @@ def download(
         If the file URL cannot be retrieved from Google Drive, or if
         skip_download is True and no Google Drive filename can be resolved.
     DownloadError
-        If the download fails (e.g., multiple temporary files exist during
+        If the download fails (e.g., the response body ends before the
+        announced number of bytes, or multiple temporary files exist during
         resume).
     """
     if not (id is None) ^ (url is None):
@@ -419,27 +445,48 @@ def download(
             headers = {"Range": f"bytes={start_size}-"}
             res = sess.get(url, headers=headers, stream=True, verify=verify)
 
-        total = res.headers.get("Content-Length")
-        if total is not None:
-            total = int(total) + start_size
+        content_length = _get_content_length_from_response(response=res)
+        total = None if content_length is None else content_length + start_size
+        expected_size = (
+            content_length if _is_content_length_comparable(response=res) else None
+        )
         if not quiet:
             pbar = tqdm.tqdm(total=total, unit="B", initial=start_size, unit_scale=True)
             stack.callback(pbar.close)
         t_start = time.time()
         downloaded = 0
-        for chunk in res.iter_content(chunk_size=CHUNK_SIZE):
-            f.write(chunk)
-            downloaded += len(chunk)
-            if not quiet:
-                pbar.update(len(chunk))
-            if progress is not None:
-                progress(downloaded + start_size, total)
-            if speed is None:
-                continue
-            elapsed_time_expected = downloaded / speed
-            elapsed_time = time.time() - t_start
-            if elapsed_time < elapsed_time_expected:
-                time.sleep(elapsed_time_expected - elapsed_time)
+        truncation_error: requests.exceptions.ChunkedEncodingError | None = None
+        try:
+            for chunk in res.iter_content(chunk_size=CHUNK_SIZE):
+                f.write(chunk)
+                downloaded += len(chunk)
+                if not quiet:
+                    pbar.update(len(chunk))
+                if progress is not None:
+                    progress(downloaded + start_size, total)
+                if speed is None:
+                    continue
+                elapsed_time_expected = downloaded / speed
+                elapsed_time = time.time() - t_start
+                if elapsed_time < elapsed_time_expected:
+                    time.sleep(elapsed_time_expected - elapsed_time)
+        except requests.exceptions.ChunkedEncodingError as e:
+            # Some HTTP client versions enforce Content-Length themselves, so a
+            # body that ends early surfaces here rather than as a short read.
+            truncation_error = e
+
+    if truncation_error is not None or (
+        expected_size is not None and downloaded < expected_size
+    ):
+        message = f"Download is incomplete: received {downloaded + start_size} bytes"
+        if expected_size is not None:
+            message += f" but the server announced {total} bytes"
+        if tmp_file is not None:
+            message += (
+                f".\nThe received bytes are kept in {tmp_file}, which resume "
+                "(--continue on the command line) picks up"
+            )
+        raise DownloadError(message + ".") from truncation_error
 
     if tmp_file is not None:
         assert isinstance(output, str)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,17 @@
+import unittest.mock
 from typing import Final
 
 GITHUB_RELEASE_URL: Final = (
     "https://github.com/wkentaro/gdown/archive/refs/tags/v4.0.0.tar.gz"
 )
+
+
+def build_response(
+    *, headers: dict[str, str], chunks: list[bytes]
+) -> unittest.mock.Mock:
+    response = unittest.mock.Mock()
+    response.status_code = 200
+    response.headers = {"Content-Type": "application/octet-stream", **headers}
+    response.iter_content.return_value = chunks
+    response.url = "https://example.com/file"
+    return response

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,6 +1,8 @@
+import http.server
 import io
 import os
 import sys
+import threading
 import unittest.mock
 from pathlib import Path
 from typing import BinaryIO
@@ -11,8 +13,10 @@ from typing import NamedTuple
 import pytest
 import requests
 
+from gdown.download import CHUNK_SIZE
 from gdown.download import GoogleDriveFileToDownload
 from gdown.download import download
+from gdown.exceptions import DownloadError
 
 from .conftest import build_response
 
@@ -377,3 +381,149 @@ def test_download_google_slides_without_extension(*, tmp_path: Path) -> None:
     )
     assert isinstance(output, str)
     assert output.endswith(".pptx")
+
+
+def test_download_keeps_part_then_resumes_when_body_ends_before_announced_size(
+    *,
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,
+) -> None:
+    output = tmp_path / "output"
+    download_session.get.return_value = build_response(
+        headers={"Content-Length": "10"}, chunks=[b"data"]
+    )
+
+    with pytest.raises(DownloadError, match="received 4 bytes.*announced 10 bytes"):
+        download(url="https://example.com/file", output=str(output), quiet=True)
+
+    assert not output.exists()
+    (part,) = tmp_path.glob("output*.part")
+    assert part.read_bytes() == b"data"
+
+    download_session.get.side_effect = [
+        download_session.get.return_value,
+        build_response(headers={"Content-Length": "6"}, chunks=[b"123456"]),
+    ]
+    download(
+        url="https://example.com/file", output=str(output), quiet=True, resume=True
+    )
+
+    assert output.read_bytes() == b"data123456"
+    assert not part.exists()
+
+
+def test_download_counts_resumed_bytes_toward_announced_size(
+    *,
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,
+) -> None:
+    output = tmp_path / "output"
+    part = tmp_path / "output.partial.part"
+    part.write_bytes(b"partial")
+    download_session.get.side_effect = [
+        build_response(headers={"Content-Length": "11"}, chunks=[b"partial"]),
+        build_response(headers={"Content-Length": "4"}, chunks=[b"da"]),
+    ]
+
+    with pytest.raises(DownloadError, match="received 9 bytes.*announced 11 bytes"):
+        download(
+            url="https://example.com/file", output=str(output), quiet=True, resume=True
+        )
+
+    assert part.read_bytes() == b"partialda"
+
+
+def test_download_fails_when_body_ends_early_for_a_caller_stream(
+    *,
+    download_session: unittest.mock.Mock,
+) -> None:
+    output = io.BytesIO()
+    download_session.get.return_value = build_response(
+        headers={"Content-Length": "10"}, chunks=[b"data"]
+    )
+
+    with pytest.raises(DownloadError, match="received 4 bytes"):
+        download(url="https://example.com/file", output=output, quiet=True)
+
+    assert not output.closed
+    assert output.getvalue() == b"data"
+
+
+def test_download_fails_when_the_transport_reports_a_broken_body(
+    *,
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,
+) -> None:
+    output = tmp_path / "output"
+    download_session.get.return_value.iter_content.side_effect = (
+        requests.exceptions.ChunkedEncodingError("connection broken")
+    )
+
+    with pytest.raises(DownloadError, match="received 0 bytes"):
+        download(url="https://example.com/file", output=str(output), quiet=True)
+
+    assert not output.exists()
+
+
+@pytest.mark.parametrize(
+    ("headers", "total"),
+    [
+        ({}, None),
+        ({"Content-Length": "not-a-number"}, None),
+        ({"Content-Length": "-1"}, None),
+        # Content-Length counts the compressed wire bytes, not the decoded ones.
+        ({"Content-Length": "10", "Content-Encoding": "gzip"}, 10),
+        # A transfer encoding makes the client ignore Content-Length.
+        ({"Content-Length": "100", "Transfer-Encoding": "chunked"}, 100),
+    ],
+)
+def test_download_accepts_body_when_announced_size_is_not_comparable(
+    *,
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,
+    headers: dict[str, str],
+    total: int | None,
+) -> None:
+    output = tmp_path / "output"
+    download_session.get.return_value = build_response(
+        headers=headers, chunks=[b"data"]
+    )
+    reported: list[tuple[int, int | None]] = []
+
+    download(
+        url="https://example.com/file",
+        output=str(output),
+        quiet=True,
+        progress=lambda current, total: reported.append((current, total)),
+    )
+
+    assert output.read_bytes() == b"data"
+    assert reported == [(4, total)]
+
+
+def test_download_keeps_part_when_the_connection_closes_early(
+    *, tmp_path: Path
+) -> None:
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(200)
+            self.send_header("Content-Length", str(2 * CHUNK_SIZE))
+            self.end_headers()
+            self.wfile.write(b"x" * (CHUNK_SIZE + 1000))
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.handle_request, daemon=True).start()
+    output = tmp_path / "output"
+
+    with pytest.raises(DownloadError, match=f"announced {2 * CHUNK_SIZE} bytes"):
+        download(
+            url=f"http://127.0.0.1:{server.server_port}/",
+            output=str(output),
+            quiet=True,
+        )
+
+    server.server_close()
+    assert not output.exists()
+    (part,) = tmp_path.glob("output*.part")
+    # How much of the unfinished chunk survives depends on the HTTP client.
+    assert len(part.read_bytes()) >= CHUNK_SIZE

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -14,6 +14,8 @@ import requests
 from gdown.download import GoogleDriveFileToDownload
 from gdown.download import download
 
+from .conftest import build_response
+
 DOWNLOAD_URL: Final[str] = (
     "https://raw.githubusercontent.com/wkentaro/gdown/3.1.0/gdown/__init__.py"
 )
@@ -37,14 +39,7 @@ def download_session(
     *,
     monkeypatch: pytest.MonkeyPatch,
 ) -> unittest.mock.Mock:
-    response = unittest.mock.Mock()
-    response.status_code = 200
-    response.headers = {
-        "Content-Type": "application/octet-stream",
-        "Content-Length": "4",
-    }
-    response.iter_content.return_value = [b"data"]
-    response.url = "https://example.com/file"
+    response = build_response(headers={"Content-Length": "4"}, chunks=[b"data"])
 
     session = unittest.mock.Mock()
     session.get.return_value = response

--- a/tests/test_download_folder.py
+++ b/tests/test_download_folder.py
@@ -12,6 +12,8 @@ from gdown.download_folder import _parse_embedded_folder_view
 from gdown.download_folder import download_folder
 from gdown.exceptions import DownloadError
 
+from .conftest import build_response
+
 here = osp.dirname(osp.abspath(__file__))
 
 
@@ -184,3 +186,44 @@ def test_download_folder_dry_run() -> None:
         assert hasattr(file, "id")
         assert hasattr(file, "path")
         assert hasattr(file, "local_path")
+
+
+def test_download_folder_fails_when_a_file_ends_before_announced_size(
+    *, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = _make_folder_root(name="folder", child_name="file.txt")
+    response = build_response(
+        headers={
+            "Content-Disposition": 'attachment; filename="file.txt"',
+            "Content-Length": "10",
+        },
+        chunks=[b"data"],
+    )
+    session = unittest.mock.Mock()
+    session.get.return_value = response
+    session.cookies = []
+
+    with (
+        unittest.mock.patch.object(
+            sys.modules["gdown.download_folder"],
+            "_download_and_parse_google_drive_link",
+            return_value=root,
+        ),
+        unittest.mock.patch.object(
+            sys.modules["gdown.download"],
+            "_get_session",
+            return_value=(session, str(tmp_path / "cookies.txt")),
+        ),
+        pytest.raises(DownloadError, match="received 4 bytes"),
+    ):
+        download_folder(
+            url="https://drive.google.com/drive/folders/dummy",
+            output=str(tmp_path) + osp.sep,
+            quiet=False,
+        )
+
+    assert "Download completed" not in capsys.readouterr().err
+    assert not (tmp_path / "folder" / "file.txt").exists()
+    part_files = list((tmp_path / "folder").glob("file.txt*.part"))
+    assert len(part_files) == 1
+    assert part_files[0].read_bytes() == b"data"


### PR DESCRIPTION
A reporter saw a folder download leave files that stop partway through, with no error and no `.part` file left behind. The stream loop treated a clean end of iteration as success, so a response that ended early was still promoted from its `.part` file to the final filename, and the folder download moved on to the next file.

`download()` now compares the bytes iteration yielded against `Content-Length` and raises `DownloadError` when they fall short, leaving the received bytes in the `.part` file that `--continue` picks up.

Three non-obvious bits:

1. The comparison is skipped whenever `Content-Length` does not describe what iteration yields — a content encoding the client decodes, a transfer encoding that makes the client ignore `Content-Length` outright, or an unparsable value. Those responses keep streaming unchecked rather than being falsely rejected. Verified against a live socket for the transfer-encoding case, where `urllib3` yields a complete 4-byte body under `Content-Length: 100`.

2. urllib3 2.x enforces `Content-Length` itself and raises `ChunkedEncodingError` before the loop can finish short, so that error is always translated into the same `DownloadError` with the same resume hint. The byte-count check still matters on urllib3 1.x, which returns the short body silently — the dependency range permits both.

3. An unparsable `Content-Length` used to abort the download with an uncaught `ValueError` from the progress-bar total; it is now treated as an unknown size. The progress-bar total itself still comes from the raw header, unchanged.

`download_folder()` needed no change: it never catches `DownloadError` from a child download, so the failure aborts the folder run before "Download completed" prints. A test pins that.

Known gaps, unchanged by this PR: a server that ignores a `Range` request still corrupts a resumed file, and repeated failures without `--continue` still leave several `.part` files (as any interrupted download does). Detecting truncation of content-encoded bodies would need comparing `response.raw.tell()` against the wire length, the way pip does; that is a larger change than this fix.

## Test plan

- [x] `tests/test_download.py`: a fail-then-`--continue` round trip, a resumed short body, a caller-supplied stream, a transport error with no announced size, and one parametrized test for the sizes that cannot be compared (missing, malformed, negative, content-encoded, transfer-encoded)
- [x] a real `http.server` on localhost that closes mid-body, exercising urllib3's own enforcement
- [x] `tests/test_download_folder.py`: a folder run aborts before "Download completed" and keeps the `.part` file
- [x] mutation-checked each new guard: removing it fails exactly one test
- [x] `make lint` and the full suite, including `-m network` (the 5 Google Drive failures reproduce on `main`)
- [x] manual CLI smoke against a local server: truncated download exits 1 with the `.part` kept, then `--continue` completes the file

Closes #477
