### PR TITLE
feat(download): verify the downloaded file against an optional hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ gdown.download(id="0B9P1L--7Wd2vNm9zMTJWOGxobkU", output="output.npz")
 url = "https://drive.google.com/file/d/0B9P1L--7Wd2vNm9zMTJWOGxobkU/view?usp=sharing"
 gdown.download(url=url, output="output.npz")
 
+# Download with hash verification
+gdown.download(
+    url=url,
+    output="output.npz",
+    hash="md5:fa837a88f0c40c513d975104edf3da17",
+)
+
 # Download with hash verification and caching
 gdown.cached_download(
     url=url,

--- a/changelog.d/484.added.md
+++ b/changelog.d/484.added.md
@@ -1,0 +1,1 @@
+Add optional checksum verification to `download()`.

--- a/gdown/__init__.py
+++ b/gdown/__init__.py
@@ -7,11 +7,13 @@ from .download import download
 from .download_folder import download_folder
 from .exceptions import DownloadError
 from .exceptions import FileURLRetrievalError
+from .exceptions import HashMismatchError
 from .extractall import extractall
 
 __all__ = [
     "DownloadError",
     "FileURLRetrievalError",
+    "HashMismatchError",
     "cached_download",
     "download",
     "download_folder",

--- a/gdown/_filehash.py
+++ b/gdown/_filehash.py
@@ -1,0 +1,34 @@
+import hashlib
+from typing import Final
+
+
+def compute_filehash(*, path: str, algorithm: str) -> str:
+    BLOCKSIZE: Final = 65536
+
+    if algorithm not in hashlib.algorithms_guaranteed:
+        raise ValueError(
+            f"Unsupported hash algorithm: {algorithm}. "
+            f"Supported algorithms: {hashlib.algorithms_guaranteed}"
+        )
+
+    algorithm_instance = getattr(hashlib, algorithm)()
+    with open(path, "rb") as f:
+        for block in iter(lambda: f.read(BLOCKSIZE), b""):
+            algorithm_instance.update(block)
+    return f"{algorithm}:{algorithm_instance.hexdigest()}"
+
+
+def assert_filehash(*, path: str, hash: str) -> None:
+    if ":" not in hash:
+        raise ValueError(
+            f"Invalid hash: {hash}. "
+            "Hash must be in the format of {algorithm}:{hash_value}."
+        )
+    algorithm = hash.split(":")[0]
+
+    hash_actual = compute_filehash(path=path, algorithm=algorithm)
+
+    if hash_actual != hash:
+        raise AssertionError(
+            f"File hash doesn't match:\nactual: {hash_actual}\nexpected: {hash}"
+        )

--- a/gdown/_filehash.py
+++ b/gdown/_filehash.py
@@ -1,5 +1,46 @@
 import hashlib
+import re
 from typing import Final
+
+from .exceptions import HashMismatchError
+
+
+def parse_filehash(*, hash: str) -> tuple[str, str]:
+    # The shake_* variants are extendable-output functions whose hexdigest()
+    # takes a mandatory length, so they have no fixed digest to compare against.
+    supported_algorithms = sorted(
+        hashlib.algorithms_guaranteed - {"shake_128", "shake_256"}
+    )
+
+    algorithm, separator, hash_value = hash.partition(":")
+    if not separator:
+        raise ValueError(
+            f"Invalid hash: {hash}. "
+            "Hash must be in the format of {algorithm}:{hash_value}."
+        )
+
+    if algorithm not in supported_algorithms:
+        raise ValueError(
+            f"Unsupported hash algorithm: {algorithm}. "
+            f"Supported algorithms: {', '.join(supported_algorithms)}"
+        )
+
+    # hexdigest() is lower case, so a hash pasted from a tool that prints upper
+    # case hex names the same file.
+    hash_value = hash_value.lower()
+    if not re.fullmatch("[0-9a-f]+", hash_value):
+        raise ValueError(f"Invalid hash: {hash}. Hash value must be hexadecimal.")
+
+    # blake2b and blake2s can produce a shorter digest, but only the default
+    # length is computed here, so a shorter one could never match.
+    digest_size = hashlib.new(algorithm).digest_size
+    if len(hash_value) != digest_size * 2:
+        raise ValueError(
+            f"Invalid hash: {hash}. "
+            f"{algorithm} hash values are {digest_size * 2} characters long."
+        )
+
+    return algorithm, hash_value
 
 
 def compute_filehash(*, path: str, algorithm: str) -> str:
@@ -29,6 +70,6 @@ def assert_filehash(*, path: str, hash: str) -> None:
     hash_actual = compute_filehash(path=path, algorithm=algorithm)
 
     if hash_actual != hash:
-        raise AssertionError(
+        raise HashMismatchError(
             f"File hash doesn't match:\nactual: {hash_actual}\nexpected: {hash}"
         )

--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import hashlib
 import os
 import os.path as osp
 import shutil
 import sys
 import tempfile
 from collections.abc import Callable
-from typing import Final
 from typing import TypedDict
 
 if sys.version_info >= (3, 12):
@@ -17,6 +15,7 @@ else:
 
 import filelock
 
+from ._filehash import assert_filehash
 from .download import download
 
 
@@ -97,7 +96,7 @@ def cached_download(
         return path
     elif osp.exists(path) and hash:
         try:
-            _assert_filehash(path=path, hash=hash)
+            assert_filehash(path=path, hash=hash)
             return path
         except AssertionError as e:
             print(e, file=sys.stderr)
@@ -124,7 +123,7 @@ def cached_download(
             **kwargs,
         )
         if hash:
-            _assert_filehash(path=temp_path, hash=hash)
+            assert_filehash(path=temp_path, hash=hash)
         with filelock.FileLock(lock_path):
             shutil.move(temp_path, path)
     except Exception:
@@ -136,35 +135,3 @@ def cached_download(
         postprocess(path)
 
     return path
-
-
-def _compute_filehash(*, path: str, algorithm: str) -> str:
-    BLOCKSIZE: Final = 65536
-
-    if algorithm not in hashlib.algorithms_guaranteed:
-        raise ValueError(
-            f"Unsupported hash algorithm: {algorithm}. "
-            f"Supported algorithms: {hashlib.algorithms_guaranteed}"
-        )
-
-    algorithm_instance = getattr(hashlib, algorithm)()
-    with open(path, "rb") as f:
-        for block in iter(lambda: f.read(BLOCKSIZE), b""):
-            algorithm_instance.update(block)
-    return f"{algorithm}:{algorithm_instance.hexdigest()}"
-
-
-def _assert_filehash(*, path: str, hash: str) -> None:
-    if ":" not in hash:
-        raise ValueError(
-            f"Invalid hash: {hash}. "
-            "Hash must be in the format of {algorithm}:{hash_value}."
-        )
-    algorithm = hash.split(":")[0]
-
-    hash_actual = _compute_filehash(path=path, algorithm=algorithm)
-
-    if hash_actual != hash:
-        raise AssertionError(
-            f"File hash doesn't match:\nactual: {hash_actual}\nexpected: {hash}"
-        )

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -24,9 +24,12 @@ import bs4
 import requests
 import tqdm
 
+from ._filehash import assert_filehash
+from ._filehash import parse_filehash
 from ._vendor._ytdlp_shim import _YDLLogger
 from .exceptions import DownloadError
 from .exceptions import FileURLRetrievalError
+from .exceptions import HashMismatchError
 from .parse_url import parse_url
 
 CHUNK_SIZE: Final = 512 * 1024  # 512KB
@@ -270,6 +273,7 @@ def download(
     progress: Callable[[int, int | None], None] | None = None,
     skip_download: bool = False,  # noqa: FBT001, FBT002
     cookies_file: str | None = None,
+    hash: str | None = None,
 ) -> str | BinaryIO | GoogleDriveFileToDownload:  # noqa: GR005 -- public API accepts both call styles
     """Download file from URL.
 
@@ -320,6 +324,13 @@ def download(
         Netscape cookies file to load before the request and save after
         every Google Drive response. Default is ~/.cache/gdown/cookies.txt.
         Ignored when use_cookies is False.
+    hash:
+        Expected hash of the downloaded file in the format of
+        {algorithm}:{hash_value} such as sha256:abcdef.... Supported algorithms
+        are those guaranteed by hashlib except shake_128 and shake_256.
+        Requires output to be a filename. When resume skips an already
+        downloaded file, that file is verified too and a mismatch raises
+        instead of downloading it again.
 
     Returns
     -------
@@ -331,7 +342,11 @@ def download(
     Raises
     ------
     ValueError
-        If neither url nor id is specified, or both are specified.
+        If neither url nor id is specified, or both are specified, or hash is
+        specified with a file object as output or with skip_download, or hash
+        is malformed or names an unsupported algorithm.
+    HashMismatchError
+        If hash is specified and the file does not match it.
     FileURLRetrievalError
         If the file URL cannot be retrieved from Google Drive, or if
         skip_download is True and no Google Drive filename can be resolved.
@@ -342,6 +357,14 @@ def download(
     """
     if not (id is None) ^ (url is None):
         raise ValueError("Either url or id has to be specified")
+    if hash is not None:
+        if output is not None and not isinstance(output, str):
+            raise ValueError("hash can only be verified when output is a filename")
+        if skip_download:
+            raise ValueError("hash cannot be verified when skip_download is True")
+        # Reject a malformed hash before spending the download it would reject.
+        algorithm, hash_value = parse_filehash(hash=hash)
+        hash = f"{algorithm}:{hash_value}"
     if id is not None:
         url = f"https://drive.google.com/uc?id={id}"
     assert url is not None
@@ -477,6 +500,8 @@ def download(
 
     if isinstance(output, str):
         if resume and os.path.isfile(output):
+            if hash is not None:
+                assert_filehash(path=output, hash=hash)
             if not quiet:
                 print(f"Skipping already downloaded file {output}", file=sys.stderr)
             return output
@@ -583,6 +608,14 @@ def download(
 
     if tmp_file is not None:
         assert isinstance(output, str)
+        if hash is not None:
+            try:
+                assert_filehash(path=tmp_file, hash=hash)
+            except HashMismatchError:
+                # The body may be corrupt rather than partial, so resuming it
+                # could only append to garbage; drop it instead of leaving it.
+                os.remove(tmp_file)
+                raise
         shutil.move(tmp_file, output)
     if isinstance(output, str) and last_modified_time:
         mtime = last_modified_time.timestamp()

--- a/gdown/exceptions.py
+++ b/gdown/exceptions.py
@@ -4,3 +4,7 @@ class DownloadError(Exception):
 
 class FileURLRetrievalError(DownloadError):
     pass
+
+
+class HashMismatchError(DownloadError, AssertionError):
+    pass

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -15,9 +15,9 @@ import pytest
 from gdown.__main__ import BROWSERS
 from gdown.__main__ import file_size
 from gdown.__main__ import main
+from gdown._filehash import assert_filehash
+from gdown._filehash import compute_filehash
 from gdown._vendor._ytdlp_cookies import SUPPORTED_BROWSERS
-from gdown.cached_download import _assert_filehash
-from gdown.cached_download import _compute_filehash
 from gdown.download_folder import _GoogleDriveFile
 
 from .conftest import GITHUB_RELEASE_URL
@@ -36,7 +36,7 @@ def _test_cli_with_md5(*, url_or_id: str, md5: str, options: list[str] | None) -
             cmd.extend(options)
         subprocess.call(cmd)
         assert os.path.exists(file_path)
-        _assert_filehash(path=file_path, hash=f"md5:{md5}")
+        assert_filehash(path=file_path, hash=f"md5:{md5}")
 
 
 def _test_cli_with_content(*, url_or_id: str, content: str) -> None:
@@ -113,7 +113,7 @@ def test_download_folder_from_gdrive() -> None:
             md5s_actual = []
             for dirpath, dirnames, filenames in os.walk(d):
                 for filename in filenames:
-                    md5_actual = _compute_filehash(
+                    md5_actual = compute_filehash(
                         path=os.path.join(dirpath, filename), algorithm="md5"
                     )[len("md5:") :]
                     md5s_actual.append(md5_actual)

--- a/tests/test__filehash.py
+++ b/tests/test__filehash.py
@@ -1,0 +1,35 @@
+import pytest
+
+from gdown._filehash import parse_filehash
+
+
+def test_parse_filehash_lower_cases_the_hash_value() -> None:
+    algorithm, hash_value = parse_filehash(hash="md5:8D777F385D3DFEC8815D20F7496026DC")
+
+    assert algorithm == "md5"
+    assert hash_value == "8d777f385d3dfec8815d20f7496026dc"
+
+
+def test_parse_filehash_accepts_a_full_length_blake2_digest() -> None:
+    hash_value = "0" * 128
+
+    assert parse_filehash(hash=f"blake2b:{hash_value}") == ("blake2b", hash_value)
+
+
+@pytest.mark.parametrize(
+    ("hash", "message"),
+    [
+        ("md5", "Hash must be in the format"),
+        ("MD5:8d777f385d3dfec8815d20f7496026dc", "Unsupported hash algorithm"),
+        # shake_* is in hashlib.algorithms_guaranteed but has no fixed digest.
+        ("shake_128:00", "Unsupported hash algorithm"),
+        ("crc32:00000000", "Unsupported hash algorithm"),
+        ("md5:zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", "must be hexadecimal"),
+        ("md5:8d777f385d3dfec8815d20f749602", "characters long"),
+        # blake2b takes a shorter digest, but only its default length is computed.
+        ("blake2b:0123456789abcdef", "characters long"),
+    ],
+)
+def test_parse_filehash_rejects_bad_hash(*, hash: str, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        parse_filehash(hash=hash)

--- a/tests/test_cached_download.py
+++ b/tests/test_cached_download.py
@@ -1,5 +1,7 @@
 import os
+import sys
 import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -30,3 +32,70 @@ def test_cached_download_sha256() -> None:
     _cached_download(
         hash="sha256:284e3029cce3ae5ee0b05866100e300046359f53ae4c77fe6b34c05aa7a72cee"
     )
+
+
+def test_cached_download_redownloads_when_cached_hash_mismatches(
+    *,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "file"
+    path.write_bytes(b"stale")
+
+    def download(
+        *,
+        url: str,  # noqa: ARG001
+        output: str,
+        **kwargs: object,  # noqa: ARG001
+    ) -> str:
+        Path(output).write_bytes(b"data")
+        return output
+
+    monkeypatch.setattr(sys.modules["gdown.cached_download"], "download", download)
+    monkeypatch.setattr(
+        sys.modules["gdown.cached_download"], "cache_root", str(tmp_path)
+    )
+
+    result = gdown.cached_download(
+        url="https://example.com/file",
+        path=str(path),
+        quiet=True,
+        hash="md5:8d777f385d3dfec8815d20f7496026dc",
+    )
+
+    assert result == str(path)
+    assert path.read_bytes() == b"data"
+
+
+@pytest.mark.parametrize(
+    ("hash", "error"),
+    [
+        ("md5:8D777F385D3DFEC8815D20F7496026DC", AssertionError),
+        ("md5:0", AssertionError),
+        ("md5:not-hexadecimal", AssertionError),
+        ("shake_128:00", TypeError),
+    ],
+)
+def test_cached_download_keeps_legacy_hash_behavior(
+    *,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    hash: str,
+    error: type[Exception],
+) -> None:
+    def download(*, output: str, **_kwargs: object) -> str:
+        Path(output).write_bytes(b"data")
+        return output
+
+    monkeypatch.setattr(sys.modules["gdown.cached_download"], "download", download)
+    monkeypatch.setattr(
+        sys.modules["gdown.cached_download"], "cache_root", str(tmp_path)
+    )
+
+    with pytest.raises(error):
+        gdown.cached_download(
+            url="https://example.com/file",
+            path=str(tmp_path / "file"),
+            quiet=True,
+            hash=hash,
+        )

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -25,6 +25,7 @@ from gdown.download import _load_cookies
 from gdown.download import _save_cookies
 from gdown.download import download
 from gdown.exceptions import DownloadError
+from gdown.exceptions import HashMismatchError
 
 from .conftest import build_google_cookie
 from .conftest import build_response
@@ -714,3 +715,188 @@ def test_get_session_loads_cookies_file(*, tmp_path: Path) -> None:
 
     assert used_file == str(cookies_file)
     assert sess.cookies.get("SID", domain=".google.com") == "saved"
+
+
+DATA_HASH_VALUE: Final[str] = "8d777f385d3dfec8815d20f7496026dc"
+DATA_HASH: Final[str] = f"md5:{DATA_HASH_VALUE}"
+
+
+def test_download_writes_output_when_hash_matches(
+    *,
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,  # noqa: ARG001
+) -> None:
+    output = tmp_path / "output"
+
+    result = download(
+        url="https://example.com/file",
+        output=str(output),
+        quiet=True,
+        use_cookies=False,
+        hash=DATA_HASH,
+    )
+
+    assert result == str(output)
+    assert output.read_bytes() == b"data"
+    assert list(tmp_path.glob("output*.part")) == []
+
+
+def test_download_writes_output_when_hash_is_upper_case(
+    *,
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,  # noqa: ARG001
+) -> None:
+    output = tmp_path / "output"
+
+    result = download(
+        url="https://example.com/file",
+        output=str(output),
+        quiet=True,
+        use_cookies=False,
+        hash=f"md5:{DATA_HASH_VALUE.upper()}",
+    )
+
+    assert result == str(output)
+    assert output.read_bytes() == b"data"
+
+
+def test_download_writes_output_when_hash_is_omitted(
+    *,
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,  # noqa: ARG001
+) -> None:
+    output = tmp_path / "output"
+
+    result = download(
+        url="https://example.com/file",
+        output=str(output),
+        quiet=True,
+        use_cookies=False,
+    )
+
+    assert result == str(output)
+    assert output.read_bytes() == b"data"
+
+
+def test_download_discards_body_when_hash_mismatches(
+    *,
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,  # noqa: ARG001
+) -> None:
+    output = tmp_path / "output"
+
+    with pytest.raises(HashMismatchError, match="File hash doesn't match"):
+        download(
+            url="https://example.com/file",
+            output=str(output),
+            quiet=True,
+            use_cookies=False,
+            hash="md5:" + "0" * 32,
+        )
+
+    assert not output.exists()
+    assert list(tmp_path.glob("output*.part")) == []
+
+
+@pytest.mark.parametrize(
+    ("hash", "message"),
+    [
+        # shake_* is in hashlib.algorithms_guaranteed but has no fixed digest.
+        ("shake_128:00", "Unsupported hash algorithm"),
+        ("crc32:00000000", "Unsupported hash algorithm"),
+        ("8d777f385d3dfec8815d20f7496026dc", "Invalid hash"),
+        ("md5:zzzz", "must be hexadecimal"),
+        (f"sha256:{DATA_HASH_VALUE}", "characters long"),
+    ],
+)
+def test_download_rejects_bad_hash_before_downloading(
+    *,
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,
+    hash: str,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        download(
+            url="https://example.com/file",
+            output=str(tmp_path / "output"),
+            quiet=True,
+            use_cookies=False,
+            hash=hash,
+        )
+
+    download_session.get.assert_not_called()
+
+
+def test_download_rejects_hash_with_file_object_output(
+    *,
+    download_session: unittest.mock.Mock,
+) -> None:
+    with pytest.raises(ValueError, match="output is a filename"):
+        download(
+            url="https://example.com/file",
+            output=io.BytesIO(),
+            quiet=True,
+            use_cookies=False,
+            hash=DATA_HASH,
+        )
+
+    download_session.get.assert_not_called()
+
+
+def test_download_rejects_hash_with_skip_download(
+    *,
+    download_session: unittest.mock.Mock,
+) -> None:
+    with pytest.raises(ValueError, match="skip_download"):
+        download(
+            url="https://example.com/file",
+            quiet=True,
+            use_cookies=False,
+            skip_download=True,
+            hash=DATA_HASH,
+        )
+
+    download_session.get.assert_not_called()
+
+
+def test_download_skips_resumed_file_when_hash_matches(
+    *,
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,
+) -> None:
+    output = tmp_path / "output"
+    output.write_bytes(b"data")
+
+    result = download(
+        url="https://example.com/file",
+        output=str(output),
+        quiet=True,
+        use_cookies=False,
+        resume=True,
+        hash=DATA_HASH,
+    )
+
+    assert result == str(output)
+    download_session.get.return_value.iter_content.assert_not_called()
+
+
+def test_download_verifies_hash_of_resume_skipped_file(
+    *,
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,  # noqa: ARG001
+) -> None:
+    output = tmp_path / "output"
+    output.write_bytes(b"stale")
+
+    with pytest.raises(HashMismatchError, match="File hash doesn't match"):
+        download(
+            url="https://example.com/file",
+            output=str(output),
+            quiet=True,
+            use_cookies=False,
+            resume=True,
+            hash=DATA_HASH,
+        )
+
+    assert output.read_bytes() == b"stale"


### PR DESCRIPTION
Closes #482.

Plain downloads can now verify caller-supplied checksums with the same hash format and errors as `cached_download()`.

This replaces the earlier revision that tightened `cached_download()` validation: the existing verifier now moves unchanged, preserving its behavior while both paths share the implementation. Failed verification removes temporary output, and resume mismatches remove the known-bad final file before raising.
