### PR TITLE
chore: adopt additional Ruff lint rules

### DIFF
--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -17,12 +17,13 @@ from .exceptions import DownloadError
 
 
 class _ShowVersionAction(argparse.Action):
+    # The callback protocol requires the full signature even when values are unused.
     def __call__(
         self,
         parser: argparse.ArgumentParser,
-        namespace: argparse.Namespace,
-        values: str | Sequence[Any] | None,
-        option_string: str | None = None,
+        namespace: argparse.Namespace,  # noqa: ARG002
+        values: str | Sequence[Any] | None,  # noqa: ARG002
+        option_string: str | None = None,  # noqa: ARG002
     ) -> None:
         print(f"gdown {__version__} at {os.path.dirname(os.path.dirname(__file__))}")
         parser.exit()

--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -39,10 +39,11 @@ if not osp.exists(cache_root):
         pass
 
 
+# Boolean parameters remain positional for backward compatibility.
 def cached_download(
     url: str | None = None,
     path: str | None = None,
-    quiet: bool = False,
+    quiet: bool = False,  # noqa: FBT001, FBT002
     postprocess: Callable[[str], object] | None = None,
     hash: str | None = None,
     **kwargs: Unpack[_DownloadKwargs],

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -114,6 +114,7 @@ def _get_modified_time_from_response(
 
 def _get_session(
     proxy: str | None,
+    *,
     use_cookies: bool,
     user_agent: str,
 ) -> tuple[requests.Session, str]:
@@ -140,21 +141,22 @@ def _get_session(
     return sess, cookies_file
 
 
+# Boolean parameters remain positional for backward compatibility.
 def download(
     url: str | None = None,
     output: str | BinaryIO | None = None,
-    quiet: bool = False,
+    quiet: bool = False,  # noqa: FBT001, FBT002
     proxy: str | None = None,
     speed: float | None = None,
-    use_cookies: bool = True,
-    verify: bool | str = True,
+    use_cookies: bool = True,  # noqa: FBT001, FBT002
+    verify: bool | str = True,  # noqa: FBT001, FBT002
     id: str | None = None,
-    resume: bool = False,
+    resume: bool = False,  # noqa: FBT001, FBT002
     format: str | None = None,
     user_agent: str | None = None,
     log_messages: dict[str, str] | None = None,
     progress: Callable[[int, int | None], None] | None = None,
-    skip_download: bool = False,
+    skip_download: bool = False,  # noqa: FBT001, FBT002
 ) -> str | BinaryIO | GoogleDriveFileToDownload:
     """Download file from URL.
 

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -13,6 +13,7 @@ import time
 import urllib.parse
 import warnings
 from collections.abc import Callable
+from http import HTTPStatus
 from http.cookiejar import MozillaCookieJar
 from typing import BinaryIO
 
@@ -254,7 +255,7 @@ def download(
         if not (gdrive_file_id and is_gdrive_download_link):
             break
 
-        if url == url_origin and res.status_code == 500:
+        if url == url_origin and res.status_code == HTTPStatus.INTERNAL_SERVER_ERROR:
             # The file could be Google Docs or Spreadsheets.
             url = f"https://drive.google.com/open?id={gdrive_file_id}"
             continue

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -52,18 +52,19 @@ def _get_directory_structure(
     return directory_structure
 
 
+# Boolean parameters remain positional for backward compatibility.
 def download_folder(
     url: str | None = None,
     id: str | None = None,
     output: str | None = None,
-    quiet: bool = False,
+    quiet: bool = False,  # noqa: FBT001, FBT002
     proxy: str | None = None,
     speed: float | None = None,
-    use_cookies: bool = True,
-    verify: bool | str = True,
+    use_cookies: bool = True,  # noqa: FBT001, FBT002
+    verify: bool | str = True,  # noqa: FBT001, FBT002
     user_agent: str | None = None,
-    skip_download: bool = False,
-    resume: bool = False,
+    skip_download: bool = False,  # noqa: FBT001, FBT002
+    resume: bool = False,  # noqa: FBT001, FBT002
 ) -> list[str] | list[GoogleDriveFileToDownload]:
     """Downloads entire folder from URL.
 
@@ -207,6 +208,7 @@ def _extract_folder_id(url: str) -> str:
 def _parse_embedded_folder_view(
     sess: requests.Session,
     folder_id: str,
+    *,
     verify: bool | str = True,
 ) -> tuple[str, list[tuple[str, str, str]]]:
     params = urllib.parse.urlencode({"id": folder_id})
@@ -273,6 +275,7 @@ def _parse_embedded_folder_view(
 def _download_and_parse_google_drive_link(
     sess: requests.Session,
     folder_id: str,
+    *,
     quiet: bool = False,
     verify: bool | str = True,
 ) -> _GoogleDriveFile:

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -5,6 +5,7 @@ import os.path as osp
 import re
 import sys
 import urllib.parse
+from http import HTTPStatus
 
 import bs4
 import requests
@@ -214,7 +215,7 @@ def _parse_embedded_folder_view(
     params = urllib.parse.urlencode({"id": folder_id})
     url = f"https://drive.google.com/embeddedfolderview?{params}"
     res = sess.get(url, verify=verify)
-    if res.status_code != 200:
+    if res.status_code != HTTPStatus.OK:
         raise DownloadError(
             f"Failed to retrieve folder contents for folder ID: {folder_id} "
             f"(status code {res.status_code}). "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ extend-select = [
   "ARG",
   "B006",
   "B008",
+  "FBT",
 ]
 select = [
   "ANN", # flake8-annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ extend-select = [
   "B006",
   "B008",
   "FBT",
+  "PLC0415",
 ]
 select = [
   "ANN", # flake8-annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ extend-select = [
   "PLC0415",
   "PLR2004",
   "RUF012",
+  "RUF022",
 ]
 select = [
   "ANN", # flake8-annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ fragments = [{ path = "README.md" }]
 markers = ["network: tests that require network access (Google Drive, GitHub)"]
 
 [tool.ruff.lint]
+extend-select = ["ARG"]
 select = [
   "ANN", # flake8-annotations
   "E",   # pycodestyle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ extend-select = [
   "FBT",
   "PLC0415",
   "PLR2004",
+  "RUF012",
 ]
 select = [
   "ANN", # flake8-annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ extend-select = [
   "B008",
   "FBT",
   "PLC0415",
+  "PLR2004",
 ]
 select = [
   "ANN", # flake8-annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ markers = ["network: tests that require network access (Google Drive, GitHub)"]
 extend-select = [
   "ARG",
   "B006",
+  "B008",
 ]
 select = [
   "ANN", # flake8-annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,10 @@ fragments = [{ path = "README.md" }]
 markers = ["network: tests that require network access (Google Drive, GitHub)"]
 
 [tool.ruff.lint]
-extend-select = ["ARG"]
+extend-select = [
+  "ARG",
+  "B006",
+]
 select = [
   "ANN", # flake8-annotations
   "E",   # pycodestyle

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -135,9 +135,7 @@ def test_download_a_folder_with_more_than_50_files() -> None:
         subprocess.check_call(cmd)
 
         filenames = sorted(os.listdir(d))
-        assert len(filenames) == 100
-        for i in range(100):
-            assert filenames[i] == f"file_{i:02d}.txt"
+        assert filenames == [f"file_{i:02d}.txt" for i in range(100)]
 
 
 # def test_download_docs_from_gdrive():

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -251,7 +251,7 @@ def test_json_flag_preserves_subfolder_path(
 
 
 def test_json_flag_does_not_download(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     root = _GoogleDriveFile(
         id="root_id",

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -50,7 +50,7 @@ def download_session(
     monkeypatch.setattr(
         sys.modules["gdown.download"],
         "_get_session",
-        lambda **kwargs: (session, "cookies.txt"),
+        lambda **_kwargs: (session, "cookies.txt"),
     )
     return session
 
@@ -110,7 +110,7 @@ def test_download_closes_resources_when_progress_raises(
 ) -> None:
     pbar = unittest.mock.Mock()
     monkeypatch.setattr(
-        sys.modules["gdown.download"].tqdm, "tqdm", lambda **kwargs: pbar
+        sys.modules["gdown.download"].tqdm, "tqdm", lambda **_kwargs: pbar
     )
 
     with pytest.raises(RuntimeError, match="stop"):
@@ -187,7 +187,7 @@ def test_download_attempts_all_cleanup_when_closers_raise(
     pbar.close.side_effect = OSError("pbar close failed")
     monkeypatch.setattr(sys.modules["gdown.download"], "open", file, raising=False)
     monkeypatch.setattr(
-        sys.modules["gdown.download"].tqdm, "tqdm", lambda **kwargs: pbar
+        sys.modules["gdown.download"].tqdm, "tqdm", lambda **_kwargs: pbar
     )
 
     with pytest.raises(OSError, match="file close failed"):
@@ -214,7 +214,7 @@ def test_download_propagates_pbar_close_error_and_keeps_part(
     pbar = unittest.mock.Mock()
     pbar.close.side_effect = OSError("pbar close failed")
     monkeypatch.setattr(
-        sys.modules["gdown.download"].tqdm, "tqdm", lambda **kwargs: pbar
+        sys.modules["gdown.download"].tqdm, "tqdm", lambda **_kwargs: pbar
     )
 
     with pytest.raises(OSError, match="pbar close failed"):
@@ -314,7 +314,7 @@ def test_download_rewrites_google_drive_share_link(
         "Content-Type": "application/octet-stream",
         "Content-Disposition": 'attachment; filename="test.bin"',
     }
-    mock_response.iter_content = lambda chunk_size: [b"data"]
+    mock_response.iter_content = lambda **_kwargs: [b"data"]
     mock_response.url = expected_url
 
     mock_sess = unittest.mock.Mock()

--- a/tests/test_download_folder.py
+++ b/tests/test_download_folder.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 import unittest.mock
 from pathlib import Path
+from typing import Final
 
 import pytest
 
@@ -128,8 +129,6 @@ def test_parse_embedded_folder_view() -> None:
     assert result is not None
     folder_name, children = result
     assert folder_name == "files_100"
-    assert len(children) == 4
-
     ids = [r[0] for r in children]
     names = [r[1] for r in children]
     types = [r[2] for r in children]
@@ -174,10 +173,11 @@ def test_parse_embedded_folder_view_malformed_html() -> None:
 
 @pytest.mark.network
 def test_download_folder_dry_run() -> None:
+    EXPECTED_FILE_COUNT: Final = 6
     url = "https://drive.google.com/drive/folders/1KpLl_1tcK0eeehzN980zbG-3M2nhbVks"
     tmp_dir = tempfile.mkdtemp()
     files = download_folder(url=url, output=tmp_dir, skip_download=True)
-    assert len(files) == 6
+    assert len(files) == EXPECTED_FILE_COUNT
     for file in files:
         assert hasattr(file, "id")
         assert hasattr(file, "path")


### PR DESCRIPTION
Aligns gdown's Ruff policy with git-hunk so the shared lint expectations are enforced here too.

#487 normalized the filesystem paths returned for nested archive members after a stronger assertion exposed the Windows bug. That behavior fix is now on `main`, leaving this diff lint-only.

Existing public boolean parameters retain targeted `FBT` suppressions instead of becoming keyword-only, preserving positional-call compatibility; private helpers use keyword-only parameters where safe. The required `argparse.Action` override parameters similarly retain their inherited names with targeted `ARG002` suppressions.

Checks: `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check`, and `uv run pytest -m 'not network' -q` (63 passed).
