### PR TITLE
fix: normalize extracted archive paths

### DIFF
--- a/gdown/extractall.py
+++ b/gdown/extractall.py
@@ -53,7 +53,7 @@ def extractall(path: str, to: str | None = None) -> list[str]:
 
 def _extractall_zip(path: str, to: str) -> list[str]:
     with zipfile.ZipFile(path, "r") as f:
-        names = f.namelist()
+        names = [osp.normpath(name) for name in f.namelist()]
         for member in names:
             member_path = osp.join(to, member)
             if not _is_within_directory(directory=to, target=member_path):
@@ -88,6 +88,6 @@ def _extractall_tar(path: str, to: str, tar_mode: _TarReadMode) -> list[str]:
                         f"target directory: {to}"
                     )
             f.extractall(path=to)
-        names = [m.path for m in f.getmembers()]
+        names = [osp.normpath(m.path) for m in f.getmembers()]
 
     return [osp.join(to, name) for name in names]

--- a/tests/test_extractall.py
+++ b/tests/test_extractall.py
@@ -28,21 +28,24 @@ def test_zip_normal(tmp_path: Path, _tmp_extract_dir: str) -> None:
 
     assert os.path.exists(os.path.join(_tmp_extract_dir, "hello.txt"))
     assert os.path.exists(os.path.join(_tmp_extract_dir, "subdir", "nested.txt"))
-    assert len(result) == 2
+    assert result == [
+        os.path.join(_tmp_extract_dir, "hello.txt"),
+        os.path.join(_tmp_extract_dir, "subdir", "nested.txt"),
+    ]
 
 
 def test_tar_normal(tmp_path: Path, _tmp_extract_dir: str) -> None:
     tar_path = str(tmp_path / "normal.tar")
     with tarfile.open(name=tar_path, mode="w") as tf:
         data = b"hello world"
-        info = tarfile.TarInfo(name="hello.txt")
+        info = tarfile.TarInfo(name="subdir/nested.txt")
         info.size = len(data)
         tf.addfile(tarinfo=info, fileobj=io.BytesIO(data))
 
     result = extractall(path=tar_path, to=_tmp_extract_dir)
 
-    assert os.path.exists(os.path.join(_tmp_extract_dir, "hello.txt"))
-    assert len(result) == 1
+    assert os.path.exists(os.path.join(_tmp_extract_dir, "subdir", "nested.txt"))
+    assert result == [os.path.join(_tmp_extract_dir, "subdir", "nested.txt")]
 
 
 def test_zip_path_traversal(tmp_path: Path, _tmp_extract_dir: str) -> None:


### PR DESCRIPTION
Makes `extractall()` return native filesystem paths on Windows for nested ZIP and TAR members.

Archive member names always use `/`; joining them without normalization produced mixed paths such as `C:\extract\subdir/nested.txt`. This surfaced when #486 strengthened the return-value assertion.

Checks: `uv run ruff check gdown/extractall.py tests/test_extractall.py`, `uv run ruff format --check gdown/extractall.py tests/test_extractall.py`, `uv run ty check`, and `uv run pytest -m 'not network' -q` (63 passed).
