### PR TITLE
chore: adopt Gruff maintainability rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ format:  # Format code
 lint:  # Lint code
 	$(call exec,uv run ruff format --check)
 	$(call exec,uv run ruff check)
+	$(call exec,uv run gruff check)
 	$(call exec,uv run ty check --no-progress)
 	$(call exec,uv run taplo fmt --check $(shell git ls-files "*.toml"))
 	$(call exec,uv run mdformat --check $(shell git ls-files "*.md"))

--- a/gdown/__init__.py
+++ b/gdown/__init__.py
@@ -1,6 +1,7 @@
 import importlib.metadata
 
 from . import exceptions
+from . import parse_url
 from .cached_download import cached_download
 from .download import download
 from .download_folder import download_folder
@@ -8,4 +9,15 @@ from .exceptions import DownloadError
 from .exceptions import FileURLRetrievalError
 from .extractall import extractall
 
+__all__ = [
+    "DownloadError",
+    "FileURLRetrievalError",
+    "cached_download",
+    "download",
+    "download_folder",
+    "exceptions",
+    "extractall",
+    "importlib",
+    "parse_url",
+]
 __version__ = importlib.metadata.version("gdown")

--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -24,12 +24,12 @@ class _ShowVersionAction(argparse.Action):
         namespace: argparse.Namespace,  # noqa: ARG002
         values: str | Sequence[Any] | None,  # noqa: ARG002
         option_string: str | None = None,  # noqa: ARG002
-    ) -> None:
+    ) -> None:  # noqa: GR005 -- inherited protocol accepts both call styles
         print(f"gdown {__version__} at {os.path.dirname(os.path.dirname(__file__))}")
         parser.exit()
 
 
-def file_size(argv: str | None) -> float | None:
+def file_size(argv: str | None) -> float | None:  # noqa: GR005 -- public API accepts both call styles
     if argv is not None:
         m = re.match(r"([0-9]+)(GB|MB|KB|B)", argv)
         if not m:

--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import tempfile
 from collections.abc import Callable
+from typing import Final
 from typing import TypedDict
 
 if sys.version_info >= (3, 12):
@@ -39,7 +40,7 @@ if not osp.exists(cache_root):
         pass
 
 
-# Boolean parameters remain positional for backward compatibility.
+# Parameters remain positional-or-keyword for backward compatibility.
 def cached_download(
     url: str | None = None,
     path: str | None = None,
@@ -47,7 +48,7 @@ def cached_download(
     postprocess: Callable[[str], object] | None = None,
     hash: str | None = None,
     **kwargs: Unpack[_DownloadKwargs],
-) -> str:
+) -> str:  # noqa: GR005 -- public API accepts both call styles
     """Cached download from URL.
 
     Parameters
@@ -137,8 +138,8 @@ def cached_download(
     return path
 
 
-def _compute_filehash(path: str, algorithm: str) -> str:
-    BLOCKSIZE = 65536
+def _compute_filehash(*, path: str, algorithm: str) -> str:
+    BLOCKSIZE: Final = 65536
 
     if algorithm not in hashlib.algorithms_guaranteed:
         raise ValueError(
@@ -153,7 +154,7 @@ def _compute_filehash(path: str, algorithm: str) -> str:
     return f"{algorithm}:{algorithm_instance.hexdigest()}"
 
 
-def _assert_filehash(path: str, hash: str) -> None:
+def _assert_filehash(*, path: str, hash: str) -> None:
     if ":" not in hash:
         raise ValueError(
             f"Invalid hash: {hash}. "

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 from http import HTTPStatus
 from http.cookiejar import MozillaCookieJar
 from typing import BinaryIO
+from typing import Final
 
 import bs4
 import requests
@@ -25,7 +26,7 @@ from .exceptions import DownloadError
 from .exceptions import FileURLRetrievalError
 from .parse_url import parse_url
 
-CHUNK_SIZE = 512 * 1024  # 512KB
+CHUNK_SIZE: Final = 512 * 1024  # 512KB
 home = osp.expanduser("~")
 
 GoogleDriveFileToDownload = collections.namedtuple(
@@ -33,7 +34,7 @@ GoogleDriveFileToDownload = collections.namedtuple(
 )
 
 
-def get_url_from_gdrive_confirmation(contents: str) -> str:
+def get_url_from_gdrive_confirmation(contents: str) -> str:  # noqa: GR005 -- public API accepts both call styles
     url = ""
     for line in contents.splitlines():
         m = re.search(r'href="(\/uc\?export=download[^"]+)', line)
@@ -78,7 +79,7 @@ def get_url_from_gdrive_confirmation(contents: str) -> str:
     return url
 
 
-def _sanitize_filename(filename: str) -> str:
+def _sanitize_filename(*, filename: str) -> str:
     filename = filename.replace("\x00", "")
     filename = filename.replace("/", "_").replace("\\", "_").strip()
     if filename in ("", ".", ".."):
@@ -86,7 +87,7 @@ def _sanitize_filename(filename: str) -> str:
     return filename
 
 
-def _get_filename_from_response(response: requests.Response) -> str | None:
+def _get_filename_from_response(*, response: requests.Response) -> str | None:
     content_disposition = urllib.parse.unquote(response.headers["Content-Disposition"])
 
     m = re.search(r"filename\*=UTF-8''(.*)", content_disposition)
@@ -101,6 +102,7 @@ def _get_filename_from_response(response: requests.Response) -> str | None:
 
 
 def _get_modified_time_from_response(
+    *,
     response: requests.Response,
 ) -> datetime.datetime | None:
     if "Last-Modified" not in response.headers:
@@ -114,8 +116,8 @@ def _get_modified_time_from_response(
 
 
 def _get_session(
-    proxy: str | None,
     *,
+    proxy: str | None,
     use_cookies: bool,
     user_agent: str,
 ) -> tuple[requests.Session, str]:
@@ -142,7 +144,7 @@ def _get_session(
     return sess, cookies_file
 
 
-# Boolean parameters remain positional for backward compatibility.
+# Parameters remain positional-or-keyword for backward compatibility.
 def download(
     url: str | None = None,
     output: str | BinaryIO | None = None,
@@ -158,7 +160,7 @@ def download(
     log_messages: dict[str, str] | None = None,
     progress: Callable[[int, int | None], None] | None = None,
     skip_download: bool = False,  # noqa: FBT001, FBT002
-) -> str | BinaryIO | GoogleDriveFileToDownload:
+) -> str | BinaryIO | GoogleDriveFileToDownload:  # noqa: GR005 -- public API accepts both call styles
     """Download file from URL.
 
     Parameters

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -6,6 +6,7 @@ import re
 import sys
 import urllib.parse
 from http import HTTPStatus
+from typing import Final
 
 import bs4
 import requests
@@ -18,10 +19,11 @@ from .exceptions import DownloadError
 
 
 class _GoogleDriveFile:
-    TYPE_FOLDER = "application/vnd.google-apps.folder"
+    TYPE_FOLDER: Final = "application/vnd.google-apps.folder"
 
     def __init__(
         self,
+        *,
         id: str,
         name: str,
         type: str,
@@ -37,23 +39,24 @@ class _GoogleDriveFile:
 
 
 def _get_directory_structure(
-    gdrive_file: _GoogleDriveFile, previous_path: str
+    *, gdrive_file: _GoogleDriveFile, previous_path: str
 ) -> list[tuple[str | None, str]]:
-    """Converts a Google Drive folder structure into a local directory list."""
-
     directory_structure = []
     for file in gdrive_file.children:
         file.name = _sanitize_filename(filename=file.name)
         if file.is_folder():
             directory_structure.append((None, osp.join(previous_path, file.name)))
-            for i in _get_directory_structure(file, osp.join(previous_path, file.name)):
+            for i in _get_directory_structure(
+                gdrive_file=file,
+                previous_path=osp.join(previous_path, file.name),
+            ):
                 directory_structure.append(i)
         elif not file.children:
             directory_structure.append((file.id, osp.join(previous_path, file.name)))
     return directory_structure
 
 
-# Boolean parameters remain positional for backward compatibility.
+# Parameters remain positional-or-keyword for backward compatibility.
 def download_folder(
     url: str | None = None,
     id: str | None = None,
@@ -66,7 +69,7 @@ def download_folder(
     user_agent: str | None = None,
     skip_download: bool = False,  # noqa: FBT001, FBT002
     resume: bool = False,  # noqa: FBT001, FBT002
-) -> list[str] | list[GoogleDriveFileToDownload]:
+) -> list[str] | list[GoogleDriveFileToDownload]:  # noqa: GR005 -- public API accepts both call styles
     """Downloads entire folder from URL.
 
     Parameters
@@ -129,7 +132,7 @@ def download_folder(
         folder_id = id
     else:
         assert url is not None
-        folder_id = _extract_folder_id(url)
+        folder_id = _extract_folder_id(url=url)
     if user_agent is None:
         # We need to use different user agent for folder download c.f., file
         user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"  # NOQA: E501
@@ -152,7 +155,9 @@ def download_folder(
     if not quiet:
         print("Retrieving folder contents completed", file=sys.stderr)
         print("Building directory structure", file=sys.stderr)
-    directory_structure = _get_directory_structure(gdrive_file, previous_path="")
+    directory_structure = _get_directory_structure(
+        gdrive_file=gdrive_file, previous_path=""
+    )
     if not quiet:
         print("Building directory structure completed", file=sys.stderr)
 
@@ -202,15 +207,15 @@ def download_folder(
     return files
 
 
-def _extract_folder_id(url: str) -> str:
+def _extract_folder_id(*, url: str) -> str:
     return urllib.parse.urlparse(url).path.rstrip("/").split("/")[-1]
 
 
 def _parse_embedded_folder_view(
+    *,
     sess: requests.Session,
     folder_id: str,
-    *,
-    verify: bool | str = True,
+    verify: bool | str,
 ) -> tuple[str, list[tuple[str, str, str]]]:
     params = urllib.parse.urlencode({"id": folder_id})
     url = f"https://drive.google.com/embeddedfolderview?{params}"
@@ -274,11 +279,11 @@ def _parse_embedded_folder_view(
 
 
 def _download_and_parse_google_drive_link(
+    *,
     sess: requests.Session,
     folder_id: str,
-    *,
-    quiet: bool = False,
-    verify: bool | str = True,
+    quiet: bool,
+    verify: bool | str,
 ) -> _GoogleDriveFile:
     folder_name, children = _parse_embedded_folder_view(
         sess=sess, folder_id=folder_id, verify=verify

--- a/gdown/extractall.py
+++ b/gdown/extractall.py
@@ -8,13 +8,13 @@ from typing import Literal
 _TarReadMode = Literal["r", "r:gz", "r:bz2"]
 
 
-def _is_within_directory(directory: str, target: str) -> bool:
+def _is_within_directory(*, directory: str, target: str) -> bool:
     abs_directory = osp.realpath(directory)
     abs_target = osp.realpath(target)
     return abs_target.startswith(abs_directory + os.sep) or abs_target == abs_directory
 
 
-def extractall(path: str, to: str | None = None) -> list[str]:
+def extractall(path: str, to: str | None = None) -> list[str]:  # noqa: GR005 -- public API accepts both call styles
     """Extract archive file.
 
     Parameters
@@ -51,7 +51,7 @@ def extractall(path: str, to: str | None = None) -> list[str]:
     return _extractall_tar(path=path, to=to, tar_mode=tar_mode)
 
 
-def _extractall_zip(path: str, to: str) -> list[str]:
+def _extractall_zip(*, path: str, to: str) -> list[str]:
     with zipfile.ZipFile(path, "r") as f:
         names = [osp.normpath(name) for name in f.namelist()]
         for member in names:
@@ -65,7 +65,7 @@ def _extractall_zip(path: str, to: str) -> list[str]:
     return [osp.join(to, name) for name in names]
 
 
-def _extractall_tar(path: str, to: str, tar_mode: _TarReadMode) -> list[str]:
+def _extractall_tar(*, path: str, to: str, tar_mode: _TarReadMode) -> list[str]:
     with tarfile.open(name=path, mode=tar_mode) as f:
         if sys.version_info >= (3, 12):
             f.extractall(path=to, filter="data")

--- a/gdown/parse_url.py
+++ b/gdown/parse_url.py
@@ -2,12 +2,12 @@ import re
 import urllib.parse
 
 
-def is_google_drive_url(url: str) -> bool:
+def is_google_drive_url(url: str) -> bool:  # noqa: GR005 -- public API accepts both call styles
     parsed = urllib.parse.urlparse(url)
     return parsed.hostname in ["drive.google.com", "docs.google.com"]
 
 
-def parse_url(url: str) -> tuple[str | None, bool]:
+def parse_url(url: str) -> tuple[str | None, bool]:  # noqa: GR005 -- public API accepts both call styles
     """Parse URLs especially for Google Drive links.
 
     file_id: ID of file on Google Drive.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ Homepage = "https://github.com/wkentaro/gdown"
 
 [dependency-groups]
 dev = [
+  "gruff>=0.0.4",
   "mdformat>=0.7.17",
   "mdformat-gfm>=1.0.0",
   "pytest>=8.3.5",
@@ -61,6 +62,9 @@ fragments = [{ path = "README.md" }]
 
 [tool.pytest.ini_options]
 markers = ["network: tests that require network access (Google Drive, GitHub)"]
+
+[tool.gruff.lint]
+select = ["GR001", "GR002", "GR003", "GR004", "GR005", "GR006"]
 
 [tool.ruff.lint]
 extend-select = [
@@ -83,6 +87,3 @@ select = [
 
 [tool.ruff.lint.isort]
 force-single-line = true
-
-[tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["F401"]

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -19,9 +19,7 @@ from .conftest import GITHUB_RELEASE_URL
 here = os.path.dirname(os.path.abspath(__file__))
 
 
-def _test_cli_with_md5(
-    url_or_id: str, md5: str, options: list[str] | None = None
-) -> None:
+def _test_cli_with_md5(*, url_or_id: str, md5: str, options: list[str] | None) -> None:
     # We can't use NamedTemporaryFile because Windows doesn't allow the subprocess
     # to write the file created by the parent process.
     with tempfile.TemporaryDirectory() as d:
@@ -34,7 +32,7 @@ def _test_cli_with_md5(
         _assert_filehash(path=file_path, hash=f"md5:{md5}")
 
 
-def _test_cli_with_content(url_or_id: str, content: str) -> None:
+def _test_cli_with_content(*, url_or_id: str, content: str) -> None:
     # We can't use NamedTemporaryFile because Windows doesn't allow the subprocess
     # to write the file created by the parent process.
     with tempfile.TemporaryDirectory() as d:
@@ -49,7 +47,7 @@ def _test_cli_with_content(url_or_id: str, content: str) -> None:
 def test_download_from_url_other_than_gdrive() -> None:
     url = "https://raw.githubusercontent.com/wkentaro/gdown/3.1.0/gdown/__init__.py"
     md5 = "2a51927dde6b146ce56b4d89ebbb5268"
-    _test_cli_with_md5(url_or_id=url, md5=md5)
+    _test_cli_with_md5(url_or_id=url, md5=md5, options=None)
 
 
 @pytest.mark.network
@@ -75,7 +73,7 @@ def test_download_large_file_from_gdrive() -> None:
 
     for file_id, md5 in file_id_and_md5s:
         try:
-            _test_cli_with_md5(url_or_id=file_id, md5=md5)
+            _test_cli_with_md5(url_or_id=file_id, md5=md5, options=None)
             break
         except AssertionError as e:
             print(e, file=sys.stderr)
@@ -158,7 +156,7 @@ def test_download_slides_from_gdrive() -> None:
 
 
 def test_json_flag_outputs_json_array(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    *, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     root = _GoogleDriveFile(
         id="root_id",
@@ -200,7 +198,7 @@ def test_json_flag_outputs_json_array(
 
 
 def test_json_flag_preserves_subfolder_path(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    *, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     root = _GoogleDriveFile(
         id="root_id",
@@ -249,6 +247,7 @@ def test_json_flag_preserves_subfolder_path(
 
 
 def test_json_flag_does_not_download(
+    *,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     root = _GoogleDriveFile(
@@ -289,7 +288,7 @@ def test_json_flag_does_not_download(
 
 
 @pytest.mark.parametrize("output", ["out.bin", "-"])
-def test_json_flag_rejects_output(output: str) -> None:
+def test_json_flag_rejects_output(*, output: str) -> None:
     cmd = [
         sys.executable,
         "-m",
@@ -304,7 +303,7 @@ def test_json_flag_rejects_output(output: str) -> None:
     assert "--json cannot be combined with -O/--output" in result.stderr
 
 
-def _fake_session_returning(headers: dict[str, str]) -> unittest.mock.Mock:
+def _fake_session_returning(*, headers: dict[str, str]) -> unittest.mock.Mock:
     response = unittest.mock.Mock()
     response.status_code = 200
     response.url = "https://drive.google.com/uc?id=child_id"
@@ -316,7 +315,7 @@ def _fake_session_returning(headers: dict[str, str]) -> unittest.mock.Mock:
 
 
 def test_json_flag_single_file_outputs_array(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    *, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(
         sys,
@@ -329,7 +328,7 @@ def test_json_flag_single_file_outputs_array(
         ],
     )
     sess = _fake_session_returning(
-        {
+        headers={
             "Content-Type": "application/octet-stream",
             "Content-Disposition": 'attachment; filename="video.webm"',
         }
@@ -350,6 +349,7 @@ def test_json_flag_single_file_outputs_array(
 
 
 def test_json_flag_single_file_without_drive_filename_raises(
+    *,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -362,7 +362,7 @@ def test_json_flag_single_file_without_drive_filename_raises(
             "--json",
         ],
     )
-    sess = _fake_session_returning({"Content-Type": "application/octet-stream"})
+    sess = _fake_session_returning(headers={"Content-Type": "application/octet-stream"})
     with (
         unittest.mock.patch.object(
             sys.modules["gdown.download"], "_get_session", return_value=(sess, "")
@@ -381,7 +381,7 @@ def test_json_flag_single_file_without_drive_filename_raises(
         ("4GB", 4.0 * 1024**3),
     ],
 )
-def test_file_size_parses_units(argv: str, expected: float) -> None:
+def test_file_size_parses_units(*, argv: str, expected: float) -> None:
     assert file_size(argv) == expected
 
 

--- a/tests/test_cached_download.py
+++ b/tests/test_cached_download.py
@@ -6,7 +6,7 @@ import pytest
 import gdown
 
 
-def _cached_download(hash: str) -> None:
+def _cached_download(*, hash: str) -> None:
     url = "https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c"
     fd, path = tempfile.mkstemp()
     os.close(fd)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -25,7 +25,7 @@ class DownloadEnv(NamedTuple):
 
 
 @pytest.fixture()
-def download_env(tmp_path: Path) -> DownloadEnv:
+def download_env(*, tmp_path: Path) -> DownloadEnv:
     return DownloadEnv(
         file_path=str(tmp_path / "file"),
         url=DOWNLOAD_URL,
@@ -34,6 +34,7 @@ def download_env(tmp_path: Path) -> DownloadEnv:
 
 @pytest.fixture()
 def download_session(
+    *,
     monkeypatch: pytest.MonkeyPatch,
 ) -> unittest.mock.Mock:
     response = unittest.mock.Mock()
@@ -56,7 +57,7 @@ def download_session(
 
 
 @pytest.fixture()
-def opened_files(monkeypatch: pytest.MonkeyPatch) -> list[BinaryIO]:
+def opened_files(*, monkeypatch: pytest.MonkeyPatch) -> list[BinaryIO]:
     files: list[BinaryIO] = []
 
     def open_file(path: str, mode: Literal["ab"]) -> BinaryIO:
@@ -74,7 +75,7 @@ def opened_files(monkeypatch: pytest.MonkeyPatch) -> list[BinaryIO]:
 
 
 @pytest.mark.network
-def test_download(download_env: DownloadEnv) -> None:
+def test_download(*, download_env: DownloadEnv) -> None:
     # Usage before https://github.com/wkentaro/gdown/pull/32
     assert (
         download(url=download_env.url, output=download_env.file_path, quiet=False)
@@ -83,7 +84,7 @@ def test_download(download_env: DownloadEnv) -> None:
 
 
 @pytest.mark.network
-def test_download_progress(download_env: DownloadEnv) -> None:
+def test_download_progress(*, download_env: DownloadEnv) -> None:
     reported: list[tuple[int, int | None]] = []
     download(
         url=download_env.url,
@@ -103,6 +104,7 @@ def test_download_progress(download_env: DownloadEnv) -> None:
 
 
 def test_download_closes_resources_when_progress_raises(
+    *,
     tmp_path: Path,
     download_session: unittest.mock.Mock,
     opened_files: list[BinaryIO],
@@ -131,6 +133,7 @@ def test_download_closes_resources_when_progress_raises(
 
 
 def test_download_closes_resources_when_resume_request_raises(
+    *,
     tmp_path: Path,
     download_session: unittest.mock.Mock,
     opened_files: list[BinaryIO],
@@ -157,6 +160,7 @@ def test_download_closes_resources_when_resume_request_raises(
 
 
 def test_download_keeps_caller_output_open_when_progress_raises(
+    *,
     download_session: unittest.mock.Mock,
 ) -> None:
     output = io.BytesIO()
@@ -176,6 +180,7 @@ def test_download_keeps_caller_output_open_when_progress_raises(
 
 
 def test_download_attempts_all_cleanup_when_closers_raise(
+    *,
     tmp_path: Path,
     download_session: unittest.mock.Mock,
     monkeypatch: pytest.MonkeyPatch,
@@ -205,6 +210,7 @@ def test_download_attempts_all_cleanup_when_closers_raise(
 
 
 def test_download_propagates_pbar_close_error_and_keeps_part(
+    *,
     tmp_path: Path,
     download_session: unittest.mock.Mock,
     opened_files: list[BinaryIO],
@@ -234,7 +240,7 @@ def test_download_propagates_pbar_close_error_and_keeps_part(
 
 
 @pytest.mark.network
-def test_download_output_dir_with_trailing_slash(tmp_path: Path) -> None:
+def test_download_output_dir_with_trailing_slash(*, tmp_path: Path) -> None:
     output_dir = str(tmp_path / "subdir") + "/"
     result = download(url=DOWNLOAD_URL, output=output_dir, quiet=True)
     assert isinstance(result, str)
@@ -243,7 +249,7 @@ def test_download_output_dir_with_trailing_slash(tmp_path: Path) -> None:
 
 
 @pytest.mark.network
-def test_download_output_dir_with_trailing_backslash(tmp_path: Path) -> None:
+def test_download_output_dir_with_trailing_backslash(*, tmp_path: Path) -> None:
     output_dir = str(tmp_path / "subdir") + "\\"
     result = download(url=DOWNLOAD_URL, output=output_dir, quiet=True)
     assert isinstance(result, str)
@@ -253,7 +259,7 @@ def test_download_output_dir_with_trailing_backslash(tmp_path: Path) -> None:
 
 
 @pytest.mark.network
-def test_download_output_existing_dir(tmp_path: Path) -> None:
+def test_download_output_existing_dir(*, tmp_path: Path) -> None:
     output_dir = tmp_path / "existing"
     output_dir.mkdir()
     result = download(url=DOWNLOAD_URL, output=str(output_dir), quiet=True)
@@ -264,7 +270,7 @@ def test_download_output_existing_dir(tmp_path: Path) -> None:
 
 @pytest.mark.network
 def test_download_resume_skips_existing_file(
-    download_env: DownloadEnv, capsys: pytest.CaptureFixture[str]
+    *, download_env: DownloadEnv, capsys: pytest.CaptureFixture[str]
 ) -> None:
     download(url=download_env.url, output=download_env.file_path, quiet=True)
     mtime_before = os.path.getmtime(download_env.file_path)
@@ -281,7 +287,7 @@ def test_download_resume_skips_existing_file(
 
 
 @pytest.mark.network
-def test_download_resume_skips_existing_file_in_dir(tmp_path: Path) -> None:
+def test_download_resume_skips_existing_file_in_dir(*, tmp_path: Path) -> None:
     output_dir = tmp_path / "subdir"
     output_dir.mkdir()
     result = download(url=DOWNLOAD_URL, output=str(output_dir), quiet=True)
@@ -304,7 +310,7 @@ def test_download_resume_skips_existing_file_in_dir(tmp_path: Path) -> None:
     ],
 )
 def test_download_rewrites_google_drive_share_link(
-    tmp_path: Path, share_url: str
+    *, tmp_path: Path, share_url: str
 ) -> None:
     expected_url = "https://drive.google.com/uc?id=0B9P1L--7Wd2vU3VUVlFnbTgtS2c"
 
@@ -332,7 +338,7 @@ def test_download_rewrites_google_drive_share_link(
         assert actual_url == expected_url
 
 
-def test_download_skip_download_returns_file_object(tmp_path: Path) -> None:
+def test_download_skip_download_returns_file_object(*, tmp_path: Path) -> None:
     file_id = "0B9P1L--7Wd2vU3VUVlFnbTgtS2c"
 
     mock_response = unittest.mock.Mock()
@@ -365,7 +371,7 @@ def test_download_skip_download_returns_file_object(tmp_path: Path) -> None:
 
 
 @pytest.mark.network
-def test_download_google_slides_without_extension(tmp_path: Path) -> None:
+def test_download_google_slides_without_extension(*, tmp_path: Path) -> None:
     # The file "gdown" in Google Drive is a Google Slides file with no extension
     # in its filename. When downloading directly, download() resolves the correct
     # .pptx extension from the Content-Disposition header.

--- a/tests/test_download_folder.py
+++ b/tests/test_download_folder.py
@@ -16,7 +16,7 @@ here = osp.dirname(osp.abspath(__file__))
 
 
 @pytest.mark.network
-def test_download_folder_google_slides_without_extension(tmp_path: Path) -> None:
+def test_download_folder_google_slides_without_extension(*, tmp_path: Path) -> None:
     # The folder contains a Google Slides file named "gdown" with no extension in
     # Google Drive. Previously, download_folder() passed this extensionless name as
     # the output path to download(), which saved the file without .pptx extension.
@@ -29,9 +29,7 @@ def test_download_folder_google_slides_without_extension(tmp_path: Path) -> None
     assert files[0].endswith(".pptx")
 
 
-def _make_folder_root(
-    name: str = "folder", child_name: str = "file.txt"
-) -> _GoogleDriveFile:
+def _make_folder_root(*, name: str, child_name: str) -> _GoogleDriveFile:
     return _GoogleDriveFile(
         id="root_id",
         name=name,
@@ -46,7 +44,7 @@ def _make_folder_root(
     )
 
 
-def test_root_folder_name_path_traversal_is_sanitized(tmp_path: Path) -> None:
+def test_root_folder_name_path_traversal_is_sanitized(*, tmp_path: Path) -> None:
     root = _make_folder_root(name="../../evil", child_name="safe_file.txt")
     output_dir = str(tmp_path) + osp.sep
 
@@ -68,8 +66,8 @@ def test_root_folder_name_path_traversal_is_sanitized(tmp_path: Path) -> None:
         assert resolved.startswith(osp.realpath(output_dir))
 
 
-def test_download_folder_propagates_download_error(tmp_path: Path) -> None:
-    root = _make_folder_root()
+def test_download_folder_propagates_download_error(*, tmp_path: Path) -> None:
+    root = _make_folder_root(name="folder", child_name="file.txt")
 
     with (
         unittest.mock.patch.object(
@@ -124,7 +122,9 @@ def test_parse_embedded_folder_view() -> None:
     mock_sess = unittest.mock.Mock()
     mock_sess.get.return_value = mock_response
 
-    result = _parse_embedded_folder_view(sess=mock_sess, folder_id="test_folder_id")
+    result = _parse_embedded_folder_view(
+        sess=mock_sess, folder_id="test_folder_id", verify=True
+    )
 
     assert result is not None
     folder_name, children = result
@@ -156,7 +156,9 @@ def test_parse_embedded_folder_view_http_error() -> None:
     mock_sess.get.return_value = mock_response
 
     with pytest.raises(DownloadError, match="status code 404"):
-        _parse_embedded_folder_view(sess=mock_sess, folder_id="nonexistent")
+        _parse_embedded_folder_view(
+            sess=mock_sess, folder_id="nonexistent", verify=True
+        )
 
 
 def test_parse_embedded_folder_view_malformed_html() -> None:
@@ -168,7 +170,7 @@ def test_parse_embedded_folder_view_malformed_html() -> None:
     mock_sess.get.return_value = mock_response
 
     with pytest.raises(DownloadError, match="page structure may have changed"):
-        _parse_embedded_folder_view(sess=mock_sess, folder_id="test")
+        _parse_embedded_folder_view(sess=mock_sess, folder_id="test", verify=True)
 
 
 @pytest.mark.network

--- a/tests/test_extractall.py
+++ b/tests/test_extractall.py
@@ -12,13 +12,13 @@ from gdown.extractall import extractall
 
 
 @pytest.fixture
-def _tmp_extract_dir(tmp_path: Path) -> str:
+def _tmp_extract_dir(*, tmp_path: Path) -> str:
     d = tmp_path / "extract"
     d.mkdir()
     return str(d)
 
 
-def test_zip_normal(tmp_path: Path, _tmp_extract_dir: str) -> None:
+def test_zip_normal(*, tmp_path: Path, _tmp_extract_dir: str) -> None:
     zip_path = str(tmp_path / "normal.zip")
     with zipfile.ZipFile(zip_path, "w") as zf:
         zf.writestr("hello.txt", "hello world")
@@ -34,7 +34,7 @@ def test_zip_normal(tmp_path: Path, _tmp_extract_dir: str) -> None:
     ]
 
 
-def test_tar_normal(tmp_path: Path, _tmp_extract_dir: str) -> None:
+def test_tar_normal(*, tmp_path: Path, _tmp_extract_dir: str) -> None:
     tar_path = str(tmp_path / "normal.tar")
     with tarfile.open(name=tar_path, mode="w") as tf:
         data = b"hello world"
@@ -48,7 +48,7 @@ def test_tar_normal(tmp_path: Path, _tmp_extract_dir: str) -> None:
     assert result == [os.path.join(_tmp_extract_dir, "subdir", "nested.txt")]
 
 
-def test_zip_path_traversal(tmp_path: Path, _tmp_extract_dir: str) -> None:
+def test_zip_path_traversal(*, tmp_path: Path, _tmp_extract_dir: str) -> None:
     zip_path = str(tmp_path / "evil.zip")
     with zipfile.ZipFile(zip_path, "w") as zf:
         info = zipfile.ZipInfo(filename="../evil.txt")
@@ -61,7 +61,7 @@ def test_zip_path_traversal(tmp_path: Path, _tmp_extract_dir: str) -> None:
     assert not os.path.exists(evil_path)
 
 
-def test_zip_absolute_path(tmp_path: Path, _tmp_extract_dir: str) -> None:
+def test_zip_absolute_path(*, tmp_path: Path, _tmp_extract_dir: str) -> None:
     zip_path = str(tmp_path / "evil.zip")
     with zipfile.ZipFile(zip_path, "w") as zf:
         info = zipfile.ZipInfo(filename="/tmp/evil.txt")
@@ -71,7 +71,7 @@ def test_zip_absolute_path(tmp_path: Path, _tmp_extract_dir: str) -> None:
         extractall(path=zip_path, to=_tmp_extract_dir)
 
 
-def test_tar_absolute_path(tmp_path: Path, _tmp_extract_dir: str) -> None:
+def test_tar_absolute_path(*, tmp_path: Path, _tmp_extract_dir: str) -> None:
     evil_path = str(tmp_path / "outside" / "evil.txt")
     tar_path = str(tmp_path / "evil.tar")
     with tarfile.open(name=tar_path, mode="w") as tf:
@@ -92,7 +92,7 @@ def test_tar_absolute_path(tmp_path: Path, _tmp_extract_dir: str) -> None:
     assert not os.path.exists(evil_path)
 
 
-def test_tar_path_traversal(tmp_path: Path, _tmp_extract_dir: str) -> None:
+def test_tar_path_traversal(*, tmp_path: Path, _tmp_extract_dir: str) -> None:
     tar_path = str(tmp_path / "evil.tar")
     with tarfile.open(name=tar_path, mode="w") as tf:
         data = b"malicious content"
@@ -111,7 +111,7 @@ def test_tar_path_traversal(tmp_path: Path, _tmp_extract_dir: str) -> None:
     assert not os.path.exists(evil_path)
 
 
-def test_tar_symlink_rejected(tmp_path: Path, _tmp_extract_dir: str) -> None:
+def test_tar_symlink_rejected(*, tmp_path: Path, _tmp_extract_dir: str) -> None:
     tar_path = str(tmp_path / "symlink.tar")
     with tarfile.open(name=tar_path, mode="w") as tf:
         info = tarfile.TarInfo(name="evil_link")
@@ -127,7 +127,7 @@ def test_tar_symlink_rejected(tmp_path: Path, _tmp_extract_dir: str) -> None:
             extractall(path=tar_path, to=_tmp_extract_dir)
 
 
-def test_tar_hardlink_rejected(tmp_path: Path, _tmp_extract_dir: str) -> None:
+def test_tar_hardlink_rejected(*, tmp_path: Path, _tmp_extract_dir: str) -> None:
     tar_path = str(tmp_path / "hardlink.tar")
     with tarfile.open(name=tar_path, mode="w") as tf:
         info = tarfile.TarInfo(name="evil_link")
@@ -143,7 +143,7 @@ def test_tar_hardlink_rejected(tmp_path: Path, _tmp_extract_dir: str) -> None:
             extractall(path=tar_path, to=_tmp_extract_dir)
 
 
-def test_tar_special_file_rejected(tmp_path: Path, _tmp_extract_dir: str) -> None:
+def test_tar_special_file_rejected(*, tmp_path: Path, _tmp_extract_dir: str) -> None:
     tar_path = str(tmp_path / "fifo.tar")
     with tarfile.open(name=tar_path, mode="w") as tf:
         info = tarfile.TarInfo(name="evil_fifo")
@@ -168,6 +168,7 @@ def test_tar_special_file_rejected(tmp_path: Path, _tmp_extract_dir: str) -> Non
     ],
 )
 def test_tar_compressed_normal(
+    *,
     suffix: str,
     write_mode: Literal["w:gz", "w:bz2"],
     tmp_path: Path,
@@ -186,12 +187,12 @@ def test_tar_compressed_normal(
     assert len(result) == 1
 
 
-def test_unsupported_format(tmp_path: Path) -> None:
+def test_unsupported_format(*, tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="no appropriate extractor"):
         extractall(path=str(tmp_path / "archive.rar"))
 
 
-def test_to_none_defaults_to_archive_parent(tmp_path: Path) -> None:
+def test_to_none_defaults_to_archive_parent(*, tmp_path: Path) -> None:
     zip_path = str(tmp_path / "a.zip")
     with zipfile.ZipFile(zip_path, "w") as zf:
         zf.writestr("hello.txt", "hello world")

--- a/tests/test_get_filename_from_response.py
+++ b/tests/test_get_filename_from_response.py
@@ -6,7 +6,7 @@ from gdown.download import _get_filename_from_response
 from gdown.download import _sanitize_filename
 
 
-def _make_response(content_disposition: str) -> MagicMock:
+def _make_response(*, content_disposition: str) -> MagicMock:
     response = MagicMock()
     response.headers = {"Content-Disposition": content_disposition}
     return response
@@ -31,7 +31,7 @@ def _make_response(content_disposition: str) -> MagicMock:
         "attachment-backslash",
     ],
 )
-def test_get_filename_from_response(content_disposition: str, expected: str) -> None:
+def test_get_filename_from_response(*, content_disposition: str, expected: str) -> None:
     response = _make_response(content_disposition=content_disposition)
     assert _get_filename_from_response(response=response) == expected
 
@@ -67,5 +67,5 @@ def test_get_filename_from_response(content_disposition: str, expected: str) -> 
         "path-traversal",
     ],
 )
-def test_sanitize_filename(filename: str, expected: str) -> None:
+def test_sanitize_filename(*, filename: str, expected: str) -> None:
     assert _sanitize_filename(filename=filename) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -220,6 +220,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "gruff" },
     { name = "mdformat" },
     { name = "mdformat-gfm" },
     { name = "pytest" },
@@ -242,6 +243,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "gruff", specifier = ">=0.0.4" },
     { name = "mdformat", specifier = ">=0.7.17" },
     { name = "mdformat-gfm", specifier = ">=1.0.0" },
     { name = "pytest", specifier = ">=8.3.5" },
@@ -251,6 +253,18 @@ dev = [
     { name = "ty", specifier = ">=0.0.29" },
     { name = "typos", specifier = ">=1.45.0" },
     { name = "yamlfix", specifier = ">=1.16.1" },
+]
+
+[[package]]
+name = "gruff"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/0e/24c140fee9989e7d7e6f5384717867842037ad6289ed82a6f2a59262d41c/gruff-0.0.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f53421c9a91e5ebe845f0ccbb02e5b449f4a72d63d7273116f04b1482eb47a4b", size = 1937646, upload-time = "2026-08-29T07:41:11.86Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9e/1b9d45affcbe2b9cfccfc90e90bce2b2c5e17e9d4b6051e2511077ffb8c9/gruff-0.0.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:225e57823c9df70b428be74118bedce5f64194969184ed69faf8f6027f90cb02", size = 1870836, upload-time = "2026-08-29T07:41:13.578Z" },
+    { url = "https://files.pythonhosted.org/packages/69/34/658ed6c931969e731ec6c6a3ba3fd5e881d72ab12756f880fb793550f6ba/gruff-0.0.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6dfd760bc120e83ee902a8ba40dafcdcd654a8dc679089c1cf1583f7aec2c6ce", size = 1894000, upload-time = "2026-08-29T07:41:15.17Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/d2/ca51b537863bbbe44d1582a7d30434210ec8b2222a0f929aec2f5951baac/gruff-0.0.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33c6c718d8385b600900ef5da6647d01cdfc9e67c5f58451f45568f6a0fd94ad", size = 2008931, upload-time = "2026-08-29T07:41:16.861Z" },
+    { url = "https://files.pythonhosted.org/packages/34/01/8cc8290e77fa1af663ae00283916c04c1195a7d1ae660f7666abdd294517/gruff-0.0.4-py3-none-win_amd64.whl", hash = "sha256:cbb2f381626136a81938b859ad4424e18c09599759ab50a42f86d9d35598c34d", size = 1915240, upload-time = "2026-08-29T07:41:18.333Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Makes agent-written Python conform to explicit maintainability policies in CI instead of relying on prompt compliance.

Three non-obvious choices:

1. GR005 remains enabled across production and tests. Established public APIs keep positional-or-keyword compatibility through documented suppressions; pytest-managed signatures declare keyword-only inputs because pytest binds fixtures and parameterized values by name.

2. Rules are selected individually rather than with `GR`, so a future Gruff release cannot silently expand CI policy.

3. The package manifest preserves the existing wildcard-import surface, including legacy module exports, while re-enabled F401 enforcement prevents future re-exports from being omitted.

Validated with `make lint` and `uv run pytest -q tests/ -m 'not network' --numprocesses=auto` (63 passed). The local network run had 15 passes and 5 Google access failures; a representative failure reproduces at the merge base, and the PR's network CI check passes.
