### PR TITLE
docs: document canonical GitHub labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@
 
 Issues are tracked in GitHub Issues (github.com/wkentaro/gdown) via the `gh` CLI. See `docs/agents/issue-tracker.md`.
 
-### Triage labels
+### Issue and pull request labels
 
-Five canonical triage roles, each mapped to its own label string. See `docs/agents/triage-labels.md`.
+Canonical issue types, triage roles, and pull-request verdicts are documented in `docs/agents/triage-labels.md`.
 
 ### Domain docs
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,15 +1,35 @@
-# Triage Labels
+# Issue and Pull Request Labels
 
-The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+## Issues
 
-| Label in mattpocock/skills | Label in our tracker | Meaning |
-| -------------------------- | -------------------- | ---------------------------------------- |
-| `needs-triage` | `needs-triage` | Maintainer needs to evaluate this issue |
-| `needs-info` | `needs-info` | Waiting on reporter for more information |
-| `ready-for-agent` | `ready-for-agent` | Fully specified, ready for an AFK agent |
-| `ready-for-human` | `ready-for-human` | Requires human implementation |
-| `wontfix` | `wontfix` | Will not be actioned |
+Every triaged issue carries exactly one `type:` label and one triage label. An issue with no triage label is fresh work for the agent to route; `needs-triage` is reserved for a decision only the maintainer can make.
 
-When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+| Type label | Meaning |
+| --------------- | --------------------------------------------------- |
+| `type: bug` | Reporting a defect to fix |
+| `type: feature` | Requesting a new capability or improvement |
+| `type: task` | Maintenance, refactor, documentation, or other work |
 
-Edit the right-hand column to match whatever vocabulary you actually use.
+| Triage label | Meaning |
+| ----------------- | -------------------------------------------- |
+| `needs-triage` | Maintainer needs to evaluate the issue |
+| `needs-info` | Waiting on the reporter for more information |
+| `ready-for-agent` | Fully specified and ready for an AFK agent |
+| `ready-for-human` | Requires human implementation |
+| `wontfix` | Will not be actioned |
+
+## Pull requests
+
+A draft pull request is still being built. A non-draft pull request with no agent verdict is ready for the agent to finalize. `needs-info` is shared with issues and means the pull request is waiting on an outside human.
+
+The agent records exactly one terminal verdict:
+
+| Agent verdict | Meaning |
+| ------------------ | ------------------------------------------------------------- |
+| `recommend-merge` | Finalized and endorsed for maintainer review and merge |
+| `recommend-close` | Recommended for maintainer review and closure |
+| `recommend-triage` | Technically sound; the maintainer must decide product or scope |
+
+`maintainer-approved` records an explicit maintainer decision to merge after required checks pass. An agent applies it only on explicit maintainer direction and never infers it from CI, mergeability, or an agent verdict. It may coexist with one agent verdict because the labels record different authorities.
+
+Verdicts record decisions; they do not merge or close pull requests. A new commit makes every applicable verdict stale: remove it and have the same authority review the new diff before renewing it.


### PR DESCRIPTION
Records the operational contract for the canonical GitHub labels now configured on `wkentaro/gdown`.

The label objects were applied separately through GitHub: `maintainer-approved` was added and the existing 11 canonical labels were refreshed; non-canonical labels were left untouched.
