### PR TITLE
chore: bump gruff to 0.0.5 and enable all rules

### DIFF
--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -30,21 +30,22 @@ class _ShowVersionAction(argparse.Action):
 
 
 def file_size(argv: str | None) -> float | None:  # noqa: GR005 -- public API accepts both call styles
-    if argv is not None:
-        m = re.match(r"([0-9]+)(GB|MB|KB|B)", argv)
-        if not m:
-            raise TypeError
-        size, unit = m.groups()
-        size = float(size)
-        if unit == "KB":
-            size *= 1024
-        elif unit == "MB":
-            size *= 1024**2
-        elif unit == "GB":
-            size *= 1024**3
-        elif unit == "B":
-            pass
-        return size
+    if argv is None:
+        return None
+    m = re.match(r"([0-9]+)(GB|MB|KB|B)", argv)
+    if not m:
+        raise TypeError
+    size, unit = m.groups()
+    size = float(size)
+    if unit == "KB":
+        size *= 1024
+    elif unit == "MB":
+        size *= 1024**2
+    elif unit == "GB":
+        size *= 1024**3
+    elif unit == "B":
+        pass
+    return size
 
 
 def main() -> None:

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -395,11 +395,11 @@ def download(
         print(log_messages.get("start", "Downloading...\n"), file=sys.stderr, end="")
         if resume:
             print("Resume:", tmp_file, file=sys.stderr)
-        if url_origin != url:
+        if url_origin == url:
+            print("From:", url, file=sys.stderr)
+        else:
             print("From (original):", url_origin, file=sys.stderr)
             print("From (redirected):", url, file=sys.stderr)
-        else:
-            print("From:", url, file=sys.stderr)
         print(
             log_messages.get(
                 "output",

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -434,11 +434,12 @@ def download(
                 pbar.update(len(chunk))
             if progress is not None:
                 progress(downloaded + start_size, total)
-            if speed is not None:
-                elapsed_time_expected = downloaded / speed
-                elapsed_time = time.time() - t_start
-                if elapsed_time < elapsed_time_expected:
-                    time.sleep(elapsed_time_expected - elapsed_time)
+            if speed is None:
+                continue
+            elapsed_time_expected = downloaded / speed
+            elapsed_time = time.time() - t_start
+            if elapsed_time < elapsed_time_expected:
+                time.sleep(elapsed_time_expected - elapsed_time)
 
     if tmp_file is not None:
         assert isinstance(output, str)

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -128,11 +128,11 @@ def download_folder(
     """
     if not (id is None) ^ (url is None):
         raise ValueError("Either url or id has to be specified")
-    if id is not None:
-        folder_id = id
-    else:
+    if id is None:
         assert url is not None
         folder_id = _extract_folder_id(url=url)
+    else:
+        folder_id = id
     if user_agent is None:
         # We need to use different user agent for folder download c.f., file
         user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"  # NOQA: E501

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ Homepage = "https://github.com/wkentaro/gdown"
 
 [dependency-groups]
 dev = [
-  "gruff>=0.0.4",
+  "gruff>=0.0.5",
   "mdformat>=0.7.17",
   "pytest>=8.3.5",
   "pytest-xdist>=3.6.1",
@@ -63,7 +63,7 @@ fragments = [{ path = "README.md" }]
 markers = ["network: tests that require network access (Google Drive, GitHub)"]
 
 [tool.gruff.lint]
-select = ["GR001", "GR002", "GR003", "GR004", "GR005", "GR006"]
+select = ["GR"]
 
 [tool.ruff.lint]
 extend-select = [

--- a/tests/test_extractall.py
+++ b/tests/test_extractall.py
@@ -84,10 +84,11 @@ def test_tar_absolute_path(*, tmp_path: Path, _tmp_extract_dir: str) -> None:
     # Python 3.12+ Unix: data filter strips the leading '/' and extracts safely.
     # Python 3.12+ Windows: data filter raises AbsolutePathError (TarError)
     #   because drive-letter paths (C:\...) remain absolute after stripping.
-    try:
+    if sys.version_info >= (3, 12) and os.name != "nt":
         extractall(path=tar_path, to=_tmp_extract_dir)
-    except (ValueError, tarfile.TarError):
-        pass
+    else:
+        with pytest.raises((ValueError, tarfile.TarError)):
+            extractall(path=tar_path, to=_tmp_extract_dir)
 
     assert not os.path.exists(evil_path)
 

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "gruff", specifier = ">=0.0.4" },
+    { name = "gruff", specifier = ">=0.0.5" },
     { name = "mdformat", specifier = ">=0.7.17" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
@@ -255,14 +255,14 @@ dev = [
 
 [[package]]
 name = "gruff"
-version = "0.0.4"
+version = "0.0.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/0e/24c140fee9989e7d7e6f5384717867842037ad6289ed82a6f2a59262d41c/gruff-0.0.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f53421c9a91e5ebe845f0ccbb02e5b449f4a72d63d7273116f04b1482eb47a4b", size = 1937646, upload-time = "2026-08-29T07:41:11.86Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/9e/1b9d45affcbe2b9cfccfc90e90bce2b2c5e17e9d4b6051e2511077ffb8c9/gruff-0.0.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:225e57823c9df70b428be74118bedce5f64194969184ed69faf8f6027f90cb02", size = 1870836, upload-time = "2026-08-29T07:41:13.578Z" },
-    { url = "https://files.pythonhosted.org/packages/69/34/658ed6c931969e731ec6c6a3ba3fd5e881d72ab12756f880fb793550f6ba/gruff-0.0.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6dfd760bc120e83ee902a8ba40dafcdcd654a8dc679089c1cf1583f7aec2c6ce", size = 1894000, upload-time = "2026-08-29T07:41:15.17Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/d2/ca51b537863bbbe44d1582a7d30434210ec8b2222a0f929aec2f5951baac/gruff-0.0.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33c6c718d8385b600900ef5da6647d01cdfc9e67c5f58451f45568f6a0fd94ad", size = 2008931, upload-time = "2026-08-29T07:41:16.861Z" },
-    { url = "https://files.pythonhosted.org/packages/34/01/8cc8290e77fa1af663ae00283916c04c1195a7d1ae660f7666abdd294517/gruff-0.0.4-py3-none-win_amd64.whl", hash = "sha256:cbb2f381626136a81938b859ad4424e18c09599759ab50a42f86d9d35598c34d", size = 1915240, upload-time = "2026-08-29T07:41:18.333Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4c/7f19aad3e7b621e73a13822e854c13195ca29366bd4952d0fd03df51981a/gruff-0.0.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:662c389fc1c090bade52c8ab991a9a63b41f3cec7108007e81479ade0b8a8043", size = 1977054, upload-time = "2026-09-01T03:37:46.342Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/3a/56990ab23561e9464e9dae2e87f2e438758c90e66e29cbe8e6f609b9b76d/gruff-0.0.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f078a6737c5a36a5a9497586875410e01a3d77002688ac5a00f9f33f577db6c3", size = 1909040, upload-time = "2026-09-01T03:37:48.432Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/f7/f78caabea24456e5af4b272d99c349cf8ed9d7893f9a94d2daa3ec5b7ed1/gruff-0.0.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e240efbea06923d2880e7028f46240f481b9cbbfa9587b00872a6e4a60cb0e71", size = 1933481, upload-time = "2026-09-01T03:37:50.309Z" },
+    { url = "https://files.pythonhosted.org/packages/61/72/b5b48628f6305709aaa9d4bf4ef5ad19cc08a4f309f0995fe7c2ae2b481e/gruff-0.0.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:728ae005c8505f3ff3a5d71de2c4013ae64fd1a6ee1f057ebaf309600b3d7b61", size = 2053551, upload-time = "2026-09-01T03:37:52.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/91/fc069b049a6cc958597b277c148232e15096e033d8cc24c1095950cb24de/gruff-0.0.5-py3-none-win_amd64.whl", hash = "sha256:df0f012ea4090c2c44ccb4261241dcf608112dfae1c40471e57edfe8cf09be68", size = 1958544, upload-time = "2026-09-01T03:37:53.703Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adopts the new opt-in rules gruff 0.0.5 shipped (GR007–GR010) by selecting the whole `GR` prefix, so future rules land automatically. The first three commits fix the five findings the new rules raised; they come first so every commit passes `gruff check`.

One non-obvious bit: the tar absolute-path test used to swallow `ValueError`/`TarError`, so it could never fail on the raise path. It now branches on Python version and OS and asserts the expected outcome for each — the platform matrix in the comment above it is unchanged.

The two `refactor` commits are branch swaps and guard inversions only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SzgSGWZFChiBcyF2Vw4rB
