### PR TITLE
ci: configure trusted PyPI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Aligns the tag-triggered release job with the workflow filename and environment registered by PyPI's trusted publisher, allowing its OIDC identity check to succeed without an API token.
