### PR TITLE
feat(cli): detect Google Drive folder URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,16 +87,19 @@ gdown "$url" -O "my_name.${filename##*.}"
 
 ```bash
 # Download an entire folder
-gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl -O /tmp/folder --folder
+gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl -O /tmp/folder
 
 # List folder contents as a JSON array (each entry has url and path)
-gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl --folder --json
+gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl --json
 
 # Filter by path and download matches
-gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl --folder --json \
+gdown https://drive.google.com/drive/folders/15uNXeRBIhVvZJIhL4yTw4IsStMhUaaxl --json \
   | jq -r '.[] | select(.path | test("shad")) | .url' \
   | xargs -n1 gdown
 ```
+
+Folder URLs are detected automatically. A bare folder ID still requires
+`--folder` because file and folder IDs have the same format.
 
 #### Google Docs, Sheets, Slides
 

--- a/changelog.d/496.changed.md
+++ b/changelog.d/496.changed.md
@@ -1,0 +1,1 @@
+Automatically detect Google Drive folder URLs, making `--folder` necessary only for ambiguous bare IDs.

--- a/gdown/__main__.py
+++ b/gdown/__main__.py
@@ -18,6 +18,7 @@ from .download import _import_cookies_from_browser
 from .download import download
 from .download_folder import download_folder
 from .exceptions import DownloadError
+from .parse_url import _parse_google_drive_folder_id
 
 BROWSERS: Final = tuple(sorted(SUPPORTED_BROWSERS))
 
@@ -131,7 +132,7 @@ def main() -> None:
     parser.add_argument(
         "--folder",
         action="store_true",
-        help="download entire folder instead of a single file",
+        help="download a folder by ID (folder URLs are detected automatically)",
     )
     parser.add_argument(
         "--json",
@@ -220,7 +221,16 @@ def main() -> None:
         id = args.url_or_id
 
     try:
-        if args.folder:
+        folder_id = _parse_google_drive_folder_id(url=url) if url is not None else None
+        is_folder = args.folder or folder_id is not None
+        if args.folder and folder_id is not None and not args.quiet:
+            print(
+                "warning: `--folder` is no longer required for folder URLs and will "
+                "be removed in a future release",
+                file=sys.stderr,
+            )
+
+        if is_folder:
             if not (args.output is None or isinstance(args.output, str)):
                 raise ValueError("--folder does not support stdout output (-O -)")
             result = download_folder(
@@ -255,7 +265,7 @@ def main() -> None:
             )
 
         if args.json:
-            files = result if args.folder else [result]
+            files = result if is_folder else [result]
             entries = []
             for file in files:
                 assert isinstance(file, GoogleDriveFileToDownload)

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -16,6 +16,7 @@ from .download import _get_session
 from .download import _sanitize_filename
 from .download import download
 from .exceptions import DownloadError
+from .parse_url import _parse_google_drive_folder_id
 
 
 class _GoogleDriveFile:
@@ -219,7 +220,10 @@ def download_folder(
 
 
 def _extract_folder_id(*, url: str) -> str:
-    return urllib.parse.urlparse(url).path.rstrip("/").split("/")[-1]
+    return (
+        _parse_google_drive_folder_id(url=url)
+        or urllib.parse.urlparse(url).path.rstrip("/").split("/")[-1]
+    )
 
 
 def _parse_embedded_folder_view(
@@ -276,12 +280,8 @@ def _parse_embedded_folder_view(
             children.append((file_id, file_name, "application/octet-stream"))
             continue
 
-        folder_match = re.match(
-            pattern=r"https://drive\.google\.com/drive/folders/([-\w]{25,})",
-            string=href,
-        )
-        if folder_match:
-            child_folder_id = folder_match.group(1)
+        child_folder_id = _parse_google_drive_folder_id(url=href)
+        if child_folder_id is not None:
             child_name = a_tag.get_text(strip=True)
             children.append((child_folder_id, child_name, _GoogleDriveFile.TYPE_FOLDER))
             continue

--- a/gdown/parse_url.py
+++ b/gdown/parse_url.py
@@ -7,6 +7,15 @@ def is_google_drive_url(url: str) -> bool:  # noqa: GR005 -- public API accepts 
     return parsed.hostname in ["drive.google.com", "docs.google.com"]
 
 
+def _parse_google_drive_folder_id(*, url: str) -> str | None:
+    parsed = urllib.parse.urlparse(url)
+    if not is_google_drive_url(url=url):
+        return None
+
+    match = re.match(r"^/drive/folders/([-\w]{25,})(?:/|$)", parsed.path)
+    return match.group(1) if match else None
+
+
 def parse_url(url: str) -> tuple[str | None, bool]:  # noqa: GR005 -- public API accepts both call styles
     """Parse URLs especially for Google Drive links.
 

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -136,7 +136,7 @@ def test_download_a_folder_with_more_than_50_files() -> None:
     url = "https://drive.google.com/drive/folders/1gd3xLkmjT8IckN6WtMbyFZvLR4exRIkn"
 
     with tempfile.TemporaryDirectory() as d:
-        cmd = ["gdown", "--no-cookies", url, "-O", d, "--folder"]
+        cmd = ["gdown", "--no-cookies", url, "-O", d]
         subprocess.check_call(cmd)
 
         filenames = sorted(os.listdir(d))
@@ -162,8 +162,39 @@ def test_download_slides_from_gdrive() -> None:
     _test_cli_with_md5(url_or_id=file_id, md5=md5, options=["--format", "pdf"])
 
 
+@pytest.mark.parametrize(
+    ("folder_args", "expected_warning"),
+    [
+        (
+            [
+                "https://drive.google.com/drive/folders/1uUbx_lRLLE9O4WnI8TS77dUOJw_DjljV"
+            ],
+            False,
+        ),
+        (
+            [
+                "https://drive.google.com/drive/folders/1uUbx_lRLLE9O4WnI8TS77dUOJw_DjljV",
+                "--folder",
+            ],
+            True,
+        ),
+        (
+            [
+                "https://drive.google.com/drive/folders/1uUbx_lRLLE9O4WnI8TS77dUOJw_DjljV",
+                "--folder",
+                "--quiet",
+            ],
+            False,
+        ),
+        (["1uUbx_lRLLE9O4WnI8TS77dUOJw_DjljV", "--folder"], False),
+    ],
+)
 def test_json_flag_outputs_json_array(
-    *, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    folder_args: list[str],
+    expected_warning: bool,
 ) -> None:
     root = _GoogleDriveFile(
         id="root_id",
@@ -180,12 +211,7 @@ def test_json_flag_outputs_json_array(
     monkeypatch.setattr(
         sys,
         "argv",
-        [
-            "gdown",
-            "https://drive.google.com/drive/folders/dummy",
-            "--folder",
-            "--json",
-        ],
+        ["gdown", "--no-cookies", *folder_args, "--json"],
     )
     with unittest.mock.patch.object(
         sys.modules["gdown.download_folder"],
@@ -195,6 +221,7 @@ def test_json_flag_outputs_json_array(
         main()
 
     captured = capsys.readouterr()
+    assert ("`--folder` is no longer required" in captured.err) is expected_warning
     entries = json.loads(captured.out)
     assert entries == [
         {
@@ -202,6 +229,32 @@ def test_json_flag_outputs_json_array(
             "path": "track.mp3",
         }
     ]
+
+
+@pytest.mark.parametrize(
+    ("args", "message"),
+    [
+        (
+            [
+                "https://drive.google.com/drive/folders/1uUbx_lRLLE9O4WnI8TS77dUOJw_DjljV",
+                "-O",
+                "-",
+            ],
+            "--folder does not support stdout output",
+        ),
+        (["https://[broken"], "Invalid IPv6 URL"),
+    ],
+)
+def test_cli_reports_invalid_input(*, args: list[str], message: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "gdown", "--no-cookies", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert message in result.stderr
+    assert "Traceback" not in result.stderr
 
 
 def test_json_flag_preserves_subfolder_path(

--- a/tests/test_download_folder.py
+++ b/tests/test_download_folder.py
@@ -112,6 +112,24 @@ def test_download_folder_closes_session_when_parsing_raises() -> None:
     session.close.assert_called_once_with()
 
 
+def test_download_folder_parses_id_before_url_suffix(*, tmp_path: Path) -> None:
+    folder_id = "1uUbx_lRLLE9O4WnI8TS77dUOJw_DjljV"
+
+    with unittest.mock.patch.object(
+        sys.modules["gdown.download_folder"],
+        "_download_and_parse_google_drive_link",
+        return_value=_make_folder_root(name="folder", child_name="file.txt"),
+    ) as parse_folder:
+        download_folder(
+            url=f"https://drive.google.com/drive/folders/{folder_id}/view",
+            output=str(tmp_path),
+            quiet=True,
+            skip_download=True,
+        )
+
+    assert parse_folder.call_args.kwargs["folder_id"] == folder_id
+
+
 def test_parse_embedded_folder_view() -> None:
     html_file = osp.join(here, "data/embedded-folder-view-sample.html")
     with open(html_file) as f:

--- a/tests/test_parse_url.py
+++ b/tests/test_parse_url.py
@@ -1,3 +1,4 @@
+from gdown.parse_url import _parse_google_drive_folder_id
 from gdown.parse_url import parse_url
 
 from .conftest import GITHUB_RELEASE_URL
@@ -5,6 +6,23 @@ from .conftest import GITHUB_RELEASE_URL
 
 def test_parse_url_non_gdrive() -> None:
     assert parse_url(GITHUB_RELEASE_URL) == (None, False)
+
+
+def test_parse_google_drive_folder_id() -> None:
+    folder_id = "1uUbx_lRLLE9O4WnI8TS77dUOJw_DjljV"
+
+    assert (
+        _parse_google_drive_folder_id(
+            url=f"https://drive.google.com/drive/folders/{folder_id}?usp=sharing"
+        )
+        == folder_id
+    )
+    assert (
+        _parse_google_drive_folder_id(
+            url=f"https://drive.google.com/file/d/{folder_id}/view"
+        )
+        is None
+    )
 
 
 def test_parse_url() -> None:


### PR DESCRIPTION
Closes #466.

Folder URLs already identify their resource type, so treating them as single-file downloads could only save Google Drive's HTML viewer page.

Bare IDs remain ambiguous and still require `--folder`; the deprecation warning therefore applies only when `--folder` redundantly accompanies a detectable folder URL.
