### PR TITLE
feat(download): verify the downloaded file against an optional hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ gdown.download(id="0B9P1L--7Wd2vNm9zMTJWOGxobkU", output="output.npz")
 url = "https://drive.google.com/file/d/0B9P1L--7Wd2vNm9zMTJWOGxobkU/view?usp=sharing"
 gdown.download(url=url, output="output.npz")
 
+# Download with hash verification
+gdown.download(
+    url=url,
+    output="output.npz",
+    hash="md5:fa837a88f0c40c513d975104edf3da17",
+)
+
 # Download with hash verification and caching
 gdown.cached_download(
     url=url,

--- a/changelog.d/484.added.md
+++ b/changelog.d/484.added.md
@@ -1,0 +1,1 @@
+Add optional checksum verification to `download()`.

--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import hashlib
 import os
 import os.path as osp
 import shutil
 import sys
 import tempfile
 from collections.abc import Callable
-from typing import Final
 from typing import TypedDict
 
 if sys.version_info >= (3, 12):
@@ -17,6 +15,7 @@ else:
 
 import filelock
 
+from .download import _assert_filehash
 from .download import download
 
 
@@ -136,35 +135,3 @@ def cached_download(
         postprocess(path)
 
     return path
-
-
-def _compute_filehash(*, path: str, algorithm: str) -> str:
-    BLOCKSIZE: Final = 65536
-
-    if algorithm not in hashlib.algorithms_guaranteed:
-        raise ValueError(
-            f"Unsupported hash algorithm: {algorithm}. "
-            f"Supported algorithms: {hashlib.algorithms_guaranteed}"
-        )
-
-    algorithm_instance = getattr(hashlib, algorithm)()
-    with open(path, "rb") as f:
-        for block in iter(lambda: f.read(BLOCKSIZE), b""):
-            algorithm_instance.update(block)
-    return f"{algorithm}:{algorithm_instance.hexdigest()}"
-
-
-def _assert_filehash(*, path: str, hash: str) -> None:
-    if ":" not in hash:
-        raise ValueError(
-            f"Invalid hash: {hash}. "
-            "Hash must be in the format of {algorithm}:{hash_value}."
-        )
-    algorithm = hash.split(":")[0]
-
-    hash_actual = _compute_filehash(path=path, algorithm=algorithm)
-
-    if hash_actual != hash:
-        raise AssertionError(
-            f"File hash doesn't match:\nactual: {hash_actual}\nexpected: {hash}"
-        )

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -2,6 +2,7 @@ import collections
 import contextlib
 import datetime
 import email.utils
+import hashlib
 import os
 import os.path as osp
 import re
@@ -144,6 +145,38 @@ def _get_modified_time_from_response(
     return email.utils.parsedate_to_datetime(raw)
 
 
+def _compute_filehash(*, path: str, algorithm: str) -> str:
+    BLOCKSIZE: Final = 65536
+
+    if algorithm not in hashlib.algorithms_guaranteed:
+        raise ValueError(
+            f"Unsupported hash algorithm: {algorithm}. "
+            f"Supported algorithms: {hashlib.algorithms_guaranteed}"
+        )
+
+    algorithm_instance = getattr(hashlib, algorithm)()
+    with open(path, "rb") as f:
+        for block in iter(lambda: f.read(BLOCKSIZE), b""):
+            algorithm_instance.update(block)
+    return f"{algorithm}:{algorithm_instance.hexdigest()}"
+
+
+def _assert_filehash(*, path: str, hash: str) -> None:
+    if ":" not in hash:
+        raise ValueError(
+            f"Invalid hash: {hash}. "
+            "Hash must be in the format of {algorithm}:{hash_value}."
+        )
+    algorithm = hash.split(":")[0]
+
+    hash_actual = _compute_filehash(path=path, algorithm=algorithm)
+
+    if hash_actual != hash:
+        raise AssertionError(
+            f"File hash doesn't match:\nactual: {hash_actual}\nexpected: {hash}"
+        )
+
+
 def _load_cookies(*, cookies_file: str) -> MozillaCookieJar:
     cookies_file = osp.expanduser(cookies_file)
     cookie_jar = MozillaCookieJar(cookies_file)
@@ -270,6 +303,7 @@ def download(
     progress: Callable[[int, int | None], None] | None = None,
     skip_download: bool = False,  # noqa: FBT001, FBT002
     cookies_file: str | None = None,
+    hash: str | None = None,
 ) -> str | BinaryIO | GoogleDriveFileToDownload:  # noqa: GR005 -- public API accepts both call styles
     """Download file from URL.
 
@@ -320,6 +354,9 @@ def download(
         Netscape cookies file to load before the request and save after
         every Google Drive response. Default is ~/.cache/gdown/cookies.txt.
         Ignored when use_cookies is False.
+    hash:
+        Expected hash of the downloaded file in the format of
+        {algorithm}:{hash_value}. Requires output to be a filename.
 
     Returns
     -------
@@ -331,7 +368,9 @@ def download(
     Raises
     ------
     ValueError
-        If neither url nor id is specified, or both are specified.
+        If neither url nor id is specified, both are specified, output is not
+        a filename when hash is specified, or hash is malformed or uses an
+        unsupported algorithm.
     FileURLRetrievalError
         If the file URL cannot be retrieved from Google Drive, or if
         skip_download is True and no Google Drive filename can be resolved.
@@ -342,6 +381,8 @@ def download(
     """
     if not (id is None) ^ (url is None):
         raise ValueError("Either url or id has to be specified")
+    if hash and output is not None and not isinstance(output, str):
+        raise ValueError("hash can only be verified when output is a filename")
     if id is not None:
         url = f"https://drive.google.com/uc?id={id}"
     assert url is not None
@@ -477,6 +518,8 @@ def download(
 
     if isinstance(output, str):
         if resume and os.path.isfile(output):
+            if hash:
+                _assert_filehash(path=output, hash=hash)
             if not quiet:
                 print(f"Skipping already downloaded file {output}", file=sys.stderr)
             return output
@@ -583,6 +626,12 @@ def download(
 
     if tmp_file is not None:
         assert isinstance(output, str)
+        if hash:
+            try:
+                _assert_filehash(path=tmp_file, hash=hash)
+            except AssertionError:
+                os.remove(tmp_file)
+                raise
         shutil.move(tmp_file, output)
     if isinstance(output, str) and last_modified_time:
         mtime = last_modified_time.timestamp()

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -518,11 +518,19 @@ def download(
 
     if isinstance(output, str):
         if resume and os.path.isfile(output):
-            if hash:
-                _assert_filehash(path=output, hash=hash)
-            if not quiet:
-                print(f"Skipping already downloaded file {output}", file=sys.stderr)
-            return output
+            try:
+                if hash:
+                    try:
+                        _assert_filehash(path=output, hash=hash)
+                    except AssertionError:
+                        os.remove(output)
+                        raise
+                if not quiet:
+                    print(f"Skipping already downloaded file {output}", file=sys.stderr)
+                return output
+            finally:
+                res.close()
+                sess.close()
 
         existing_tmp_files = []
         for file in os.listdir(osp.dirname(output) or "."):
@@ -630,6 +638,14 @@ def download(
             try:
                 _assert_filehash(path=tmp_file, hash=hash)
             except AssertionError:
+                os.remove(tmp_file)
+                if os.path.isfile(output):
+                    try:
+                        _assert_filehash(path=output, hash=hash)
+                    except AssertionError:
+                        os.remove(output)
+                raise
+            except ValueError:
                 os.remove(tmp_file)
                 raise
         shutil.move(tmp_file, output)

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -16,8 +16,8 @@ from gdown.__main__ import BROWSERS
 from gdown.__main__ import file_size
 from gdown.__main__ import main
 from gdown._vendor._ytdlp_cookies import SUPPORTED_BROWSERS
-from gdown.cached_download import _assert_filehash
-from gdown.cached_download import _compute_filehash
+from gdown.download import _assert_filehash
+from gdown.download import _compute_filehash
 from gdown.download_folder import _GoogleDriveFile
 
 from .conftest import GITHUB_RELEASE_URL

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -417,6 +417,7 @@ def test_download_discards_file_when_hash_mismatches(
     download_session: unittest.mock.Mock,  # noqa: ARG001
 ) -> None:
     output = tmp_path / "output"
+    output.write_bytes(b"stale")
 
     with pytest.raises(AssertionError, match="File hash doesn't match"):
         download(
@@ -459,6 +460,7 @@ def test_download_rejects_unsupported_hash_algorithm(
         )
 
     assert not output.exists()
+    assert list(tmp_path.glob("output*.part")) == []
 
 
 def test_download_rejects_hash_with_file_object_output(
@@ -491,6 +493,10 @@ def test_download_verifies_file_skipped_by_resume(
             resume=True,
             hash=DATA_MD5,
         )
+
+    assert not output.exists()
+    download_session.get.return_value.close.assert_called_once_with()
+    download_session.close.assert_called_once_with()
 
 
 def test_download_keeps_part_then_resumes_when_body_ends_before_announced_size(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -32,6 +32,7 @@ from .conftest import build_response
 DOWNLOAD_URL: Final[str] = (
     "https://raw.githubusercontent.com/wkentaro/gdown/3.1.0/gdown/__init__.py"
 )
+DATA_MD5: Final[str] = "md5:8d777f385d3dfec8815d20f7496026dc"
 
 
 class DownloadEnv(NamedTuple):
@@ -390,6 +391,106 @@ def test_download_google_slides_without_extension(*, tmp_path: Path) -> None:
     )
     assert isinstance(output, str)
     assert output.endswith(".pptx")
+
+
+def test_download_saves_file_when_hash_matches(
+    *,
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,  # noqa: ARG001
+) -> None:
+    output = tmp_path / "output"
+
+    result = download(
+        url="https://example.com/file",
+        output=str(output),
+        quiet=True,
+        hash=DATA_MD5,
+    )
+
+    assert result == str(output)
+    assert output.read_bytes() == b"data"
+
+
+def test_download_discards_file_when_hash_mismatches(
+    *,
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,  # noqa: ARG001
+) -> None:
+    output = tmp_path / "output"
+
+    with pytest.raises(AssertionError, match="File hash doesn't match"):
+        download(
+            url="https://example.com/file",
+            output=str(output),
+            quiet=True,
+            hash="md5:" + "0" * 32,
+        )
+
+    assert not output.exists()
+    assert list(tmp_path.glob("output*.part")) == []
+
+
+def test_download_saves_file_without_hash(
+    *,
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,  # noqa: ARG001
+) -> None:
+    output = tmp_path / "output"
+
+    result = download(url="https://example.com/file", output=str(output), quiet=True)
+
+    assert result == str(output)
+    assert output.read_bytes() == b"data"
+
+
+def test_download_rejects_unsupported_hash_algorithm(
+    *,
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,  # noqa: ARG001
+) -> None:
+    output = tmp_path / "output"
+
+    with pytest.raises(ValueError, match="Unsupported hash algorithm: crc32"):
+        download(
+            url="https://example.com/file",
+            output=str(output),
+            quiet=True,
+            hash="crc32:adf3f363",
+        )
+
+    assert not output.exists()
+
+
+def test_download_rejects_hash_with_file_object_output(
+    *, download_session: unittest.mock.Mock
+) -> None:
+    with pytest.raises(ValueError, match="output is a filename"):
+        download(
+            url="https://example.com/file",
+            output=io.BytesIO(),
+            quiet=True,
+            hash=DATA_MD5,
+        )
+
+    download_session.get.assert_not_called()
+
+
+def test_download_verifies_file_skipped_by_resume(
+    *,
+    tmp_path: Path,
+    download_session: unittest.mock.Mock,  # noqa: ARG001
+) -> None:
+    output = tmp_path / "output"
+    output.write_bytes(b"stale")
+
+    with pytest.raises(AssertionError, match="File hash doesn't match"):
+        download(
+            url="https://example.com/file",
+            output=str(output),
+            quiet=True,
+            resume=True,
+            hash=DATA_MD5,
+        )
 
 
 def test_download_keeps_part_then_resumes_when_body_ends_before_announced_size(


### PR DESCRIPTION
Closes #482.

Plain downloads can now verify caller-supplied checksums with the same hash format and errors as `cached_download()`.

The existing verifier moves unchanged, preserving `cached_download()` behavior while both paths share the implementation. Failed verification removes temporary output, and resume mismatches remove the known-bad final file before raising.
