### PR TITLE
fix: scope cache staging to each download

### DIFF
--- a/changelog.d/500.fixed.md
+++ b/changelog.d/500.fixed.md
@@ -1,0 +1,1 @@
+Remove cached-download staging directories after success or interruption, and create the cache on demand instead of during import.

--- a/gdown/cached_download.py
+++ b/gdown/cached_download.py
@@ -33,11 +33,6 @@ class _DownloadKwargs(TypedDict, total=False):
 
 
 cache_root = osp.join(osp.expanduser("~"), ".cache/gdown")
-if not osp.exists(cache_root):
-    try:
-        os.makedirs(cache_root)
-    except OSError:
-        pass
 
 
 # Parameters remain positional-or-keyword for backward compatibility.
@@ -108,8 +103,8 @@ def cached_download(
         os.makedirs(osp.dirname(path))
     except OSError:
         pass
-    temp_root = tempfile.mkdtemp(dir=cache_root)
-    try:
+    os.makedirs(cache_root, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=cache_root) as temp_root:
         temp_path = osp.join(temp_root, "dl")
 
         log_message_hash = f"Hash: {hash}\n" if hash else ""
@@ -127,9 +122,6 @@ def cached_download(
             _assert_filehash(path=temp_path, hash=hash)
         with filelock.FileLock(lock_path):
             shutil.move(temp_path, path)
-    except Exception:
-        shutil.rmtree(temp_root)
-        raise
 
     # postprocess
     if postprocess is not None:

--- a/tests/test_cached_download.py
+++ b/tests/test_cached_download.py
@@ -1,5 +1,8 @@
 import os
+import subprocess
+import sys
 import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -30,3 +33,53 @@ def test_cached_download_sha256() -> None:
     _cached_download(
         hash="sha256:284e3029cce3ae5ee0b05866100e300046359f53ae4c77fe6b34c05aa7a72cee"
     )
+
+
+@pytest.mark.parametrize("outcome", ["success", "failure", "interrupt", "hash"])
+def test_cached_download_cleans_staging(
+    *, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, outcome: str
+) -> None:
+    cache = tmp_path / "cache"
+    monkeypatch.setattr(sys.modules["gdown.cached_download"], "cache_root", str(cache))
+    output = tmp_path / "output"
+
+    def write_download(*, output: str, **_kwargs: object) -> str:
+        Path(output).write_bytes(b"data")
+        if outcome == "failure":
+            raise RuntimeError("failed")
+        if outcome == "interrupt":
+            raise KeyboardInterrupt
+        return output
+
+    monkeypatch.setattr(
+        sys.modules["gdown.cached_download"], "download", write_download
+    )
+    if outcome == "success":
+        assert gdown.cached_download(
+            url="https://example.com/file", path=str(output), quiet=True
+        ) == str(output)
+        assert output.read_bytes() == b"data"
+    else:
+        error = {
+            "failure": RuntimeError,
+            "interrupt": KeyboardInterrupt,
+            "hash": AssertionError,
+        }[outcome]
+        with pytest.raises(error):
+            gdown.cached_download(
+                url="https://example.com/file",
+                path=str(output),
+                quiet=True,
+                hash="md5:wrong" if outcome == "hash" else None,
+            )
+        assert not output.exists()
+    assert not [path for path in cache.iterdir() if path.is_dir()]
+
+
+def test_import_does_not_create_cache(*, tmp_path: Path) -> None:
+    subprocess.run(
+        [sys.executable, "-c", "import gdown"],
+        env={**os.environ, "HOME": str(tmp_path), "USERPROFILE": str(tmp_path)},
+        check=True,
+    )
+    assert not (tmp_path / ".cache").exists()


### PR DESCRIPTION
Successful cached downloads leave empty staging directories, and keyboard interruption leaves staging content behind. Use the standard library's temporary-directory scope and create the cache only when a download needs it, so importing gdown no longer writes to disk.

Hash verification and final publication remain inside staging ownership; postprocessing runs after publication and cleanup. No new dependency or caller configuration is needed.

Verified the success, interruption, and import regressions fail on main. Success, download failure, interruption, hash mismatch, and import checks pass here; `make lint` and all 105 offline tests pass. Live Drive tests were not run locally.

Includes the shared one-line folder fixture repair so this branch passes independently of the companion architecture PRs.

Combined validation with all three architecture fixes applied: all 113 offline tests pass. Companion PRs: #499, #500, #501; deferred naming-contract decision: #498.
