### PR TITLE
fix: honor explicit user agents for folder file downloads

### DIFF
--- a/changelog.d/501.fixed.md
+++ b/changelog.d/501.fixed.md
@@ -1,0 +1,1 @@
+Honor an explicitly supplied user agent for file downloads within folders while retaining the existing default user agents.

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -139,14 +139,12 @@ def download_folder(
         folder_id = _extract_folder_id(url=url)
     else:
         folder_id = id
-    if user_agent is None:
-        # We need to use different user agent for folder download c.f., file
-        user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"  # NOQA: E501
-
+    FOLDER_USER_AGENT: Final = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"  # NOQA: E501
     sess, _ = _get_session(
         proxy=proxy,
         use_cookies=use_cookies,
-        user_agent=user_agent,
+        # Folder listing needs a different default agent than file download.
+        user_agent=FOLDER_USER_AGENT if user_agent is None else user_agent,
         cookies_file=cookies_file,
     )
     try:
@@ -214,6 +212,7 @@ def download_folder(
                     verify=verify,
                     resume=resume,
                     cookies_file=cookies_file,
+                    user_agent=user_agent,
                 )
             except DownloadError as e:
                 failed_paths.append(local_path)

--- a/tests/test_download_folder.py
+++ b/tests/test_download_folder.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Final
 
 import pytest
+import requests
 
 from gdown.download_folder import _GoogleDriveFile
 from gdown.download_folder import _parse_embedded_folder_view
@@ -351,3 +352,44 @@ def test_download_folder_continues_after_truncation_then_resumes(
         assert stderr == ""
     else:
         assert "Download completed\n" in stderr
+
+
+@pytest.mark.parametrize("user_agent", [None, "custom-agent"])
+def test_download_folder_preserves_user_agent(
+    *, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, user_agent: str | None
+) -> None:
+    agents = []
+    file_id = "x" * 25
+
+    def get_response(
+        session: requests.Session, url: str, **_kwargs: object
+    ) -> unittest.mock.Mock:
+        agents.append(session.headers["User-Agent"])
+        if "embeddedfolderview" in url:
+            response = unittest.mock.Mock()
+            response.status_code = 200
+            response.text = (
+                "<title>folder</title>"
+                f'<a href="https://drive.google.com/file/d/{file_id}/view">file.txt</a>'
+            )
+            return response
+        return build_response(
+            headers={"Content-Disposition": 'attachment; filename="file.txt"'},
+            chunks=[b"data"],
+        )
+
+    monkeypatch.setattr(requests.Session, "get", get_response)
+    files = download_folder(
+        id="folder-id",
+        output=str(tmp_path),
+        quiet=True,
+        use_cookies=False,
+        user_agent=user_agent,
+    )
+    assert files == [str(tmp_path / "file.txt")]
+    assert (tmp_path / "file.txt").read_bytes() == b"data"
+    if user_agent is None:
+        assert "Chrome/98" in agents[0]
+        assert "Chrome/39" in agents[1]
+    else:
+        assert agents == [user_agent, user_agent]


### PR DESCRIPTION
An explicit folder user agent reaches listing requests but is lost when downloading the child files. Forward the caller's value to child downloads and apply the folder-specific default only where the listing session is created, so the parameter keeps one meaning and each file download still picks its own default when no override is supplied.

An offline test drives the real folder parser and downloader and records request session headers. It reproduces the custom-agent failure on main and checks both custom and default behavior here. `make lint` and all 102 offline tests pass; live Drive tests were not run locally.

Companion PRs: #499, #500; deferred naming-contract decision: #498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VsBCZjT7T1QfH2qbBrnYR
