### PR TITLE
docs: decide folder Listing path for Google-native files

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,15 +5,19 @@ Command-line tool and Python library for downloading files and folders from Goog
 ## Language
 
 **Drive filename**:
-The true name Google Drive holds for a file, carrying its real extension. For a single file it is read from the `Content-Disposition` response header; for a folder it is read from the embedded folder-view HTML. Distinct from the URL basename, which for a Drive download URL is meaningless (e.g. `uc`, `open`).
+The true name Google Drive holds for a file, carrying its real extension. For a single file it is read from the `Content-Disposition` response header; for an ordinary file in a folder it is read from the embedded folder-view HTML. For a Google-native file it is the export filename from the `Content-Disposition` header, since the folder view shows only the extensionless Drive name. Distinct from the URL basename, which for a Drive download URL is meaningless (e.g. `uc`, `open`).
 _Avoid_: output name, basename
+
+**Google-native file**:
+A Google Docs, Sheets, or Slides entry. Drive holds it in its own format, so downloading means exporting to a chosen format (`.docx`, `.xlsx`, `.pptx` by default) and the written filename always carries the export extension the Drive name lacks. Recognized in a folder by its `docs.google.com` link, never by whether the Drive name contains a dot. Everything else in a folder is an ordinary file: stored bytes whose Drive name is already the written filename.
+_Avoid_: document, export (as a noun for the file), extensionless file
 
 **Listing**:
 The `--json` output: a JSON array of `{url, path}` entries describing what would be downloaded, emitted instead of downloading. A dry run that resolves names without fetching file bodies. Works for both a single file and a folder; takes no output destination (combining with `-O`/`--output`, including `-O -`, is a hard error).
 _Avoid_: manifest, index, dump
 
 **path** (in a Listing entry):
-The location a file would be written to, relative to the download root. For a folder, includes the directory structure. For a single file, it is the bare Drive filename. Always a real Drive filename; never a URL-basename fallback.
+The location a file would be written to, relative to the download root. For a folder, includes the directory structure. For a single file, it is the bare Drive filename. Always a real Drive filename; never a URL-basename fallback. A folder Listing resolves the export filename of each Google-native file with one request per such file; ordinary files are never probed. If any probe fails, the whole Listing fails.
 
 **Cookies file**:
 The one Netscape-format file gdown reads when it opens a session and rewrites while resolving each Google Drive file, even under `--json`, `~/.cache/gdown/cookies.txt` unless `--cookies` names another. `--cookies-from-browser` copies a browser's Google cookies into it, after which it holds a signed-in session and is written owner-only.
@@ -28,3 +32,5 @@ The probe result returned by both downloaders under `skip_download=True`: `(id, 
 > **Maintainer:** The Drive filename. Same guarantee as a folder entry: a real name with its real extension, never `uc`.
 > **Dev:** And if there's no `Content-Disposition`, like a non-Drive URL?
 > **Maintainer:** Then there's no Drive filename to report. We error out rather than emit a bad name. The Listing only ever contains real names.
+> **Dev:** A folder holds a Slides deck named `report.v2`. What's its `path`?
+> **Maintainer:** `report.v2.pptx`, under its subdirectory. Listing `path` is what gets written, so a Google-native file costs one probe request to learn its export name. The `.jpg` next to it is written under its listed name and never probed.

--- a/docs/adr/0003-folder-listing-path-is-written-filename.md
+++ b/docs/adr/0003-folder-listing-path-is-written-filename.md
@@ -1,0 +1,65 @@
+# 3. Folder Listing `path` is the written filename, probing Google-native files only
+
+Date: 2026-09-06
+
+## Status
+
+Accepted
+
+## Context
+
+A folder Listing (`--json`, `download_folder(skip_download=True)`) reports one
+`{url, path}` entry per file from the embedded folder view alone, so it costs no
+per-file requests. The folder view shows an ordinary file's full Drive filename
+but only the extensionless Drive name of a Google-native file (Docs, Sheets,
+Slides), whose written filename gains the export extension (`.docx`, `.xlsx`,
+`.pptx`).
+
+The folder parser can tell the two apart by link host, but download planning
+guessed from whether the name contained a dot: a dotted name was trusted as-is
+and an undotted name was resolved from the download response. A Google-native
+file named `report.v2` exported as `report.v2.pptx` was therefore written as
+`report.v2` (GitHub #498). Fixing the guess forces a decision on what a folder
+Listing `path` promises for a Google-native file. Three options:
+
+- Listing `path` is the written filename. Each Google-native entry costs one
+  request to read the export filename from `Content-Disposition`; ordinary
+  entries stay unprobed.
+- Listing `path` is the Drive name as shown in the folder view. No extra
+  requests, but a Google-native entry's `path` is not the filename that will
+  be written, so `CONTEXT.md`'s definition of `path` would need an exception
+  and callers could not predict on-disk names from the Listing.
+- Every entry is probed and `path` is always the response filename. Uniform,
+  but doubles requests for an all-ordinary folder for no naming gain, and lets
+  a mismatched response header rename an ordinary file.
+
+The single-file Listing already resolves its `path` from the response, and
+already errors out rather than emit a name it cannot resolve.
+
+## Decision
+
+A folder Listing `path` is the filename that would be written, relative to the
+download root and including nested directories. For a Google-native file that
+is the export filename, resolved with one request per such file through the
+same probe the single-file Listing uses. Ordinary files are written under, and
+listed as, their folder-view Drive filename and are never probed. A failed
+probe fails the whole Listing.
+
+Download planning routes on the parser's native/ordinary distinction, not on
+the presence of a dot in the name. `GoogleDriveFileToDownload` keeps its
+`(id, path, local_path)` shape. Choosing an export format for files inside a
+folder is a separate feature and not part of this decision.
+
+## Consequences
+
+- `CONTEXT.md`'s definition of `path` stays literally true for every entry:
+  what a Listing prints is what a download writes.
+- A folder Listing costs one extra request per Google-native file. Folders of
+  ordinary files remain request-free beyond the folder view itself.
+- A Google-native file's Listing `path` changes from the bare Drive name to the
+  export filename. Anyone parsing folder `--json` output for those entries sees
+  the new, correct name.
+- A probe failure (permission, quota) makes the folder Listing fail rather than
+  print a partial or misleading list, matching the single-file rule.
+- Ordinary files keep the listed name even when the response header differs,
+  so nested paths and resume continue to key on the folder view.


### PR DESCRIPTION
Records the naming contract decided while triaging #498, ahead of the fix, so the implementation PR has a settled target.

The decision: a folder Listing `path` is the filename that would be written. A Google-native file (Docs, Sheets, Slides) costs one probe request under `--json` to learn its export name; ordinary files keep the folder-view name and are never probed; a failed probe fails the whole Listing. The two rejected alternatives and their costs are in the ADR.

Docs only. The dot heuristic in folder download planning stays until the fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TenvgZcXbdtwSKHh8Q3HQd
