### PR TITLE
fix: preserve saved cookies after browser extraction errors

### DIFF
--- a/changelog.d/504.fixed.md
+++ b/changelog.d/504.fixed.md
@@ -1,0 +1,1 @@
+Preserve the saved cookies file when browser cookie extraction reports an error instead of replacing working session cookies with invalid decrypted values.

--- a/gdown/download.py
+++ b/gdown/download.py
@@ -189,6 +189,11 @@ class _CookieExtractionLogger(_YDLLogger):
     def __init__(self) -> None:
         super().__init__()
         self._seen: set[str] = set()
+        self._error_message: str | None = None
+
+    @property
+    def error_message(self) -> str | None:
+        return self._error_message
 
     def warning(
         self, message: str, /, *, once: bool = False, only_once: bool = False
@@ -198,7 +203,9 @@ class _CookieExtractionLogger(_YDLLogger):
         self._seen.add(message)
         print(f"warning: {message}", file=sys.stderr)
 
-    def error(self, message: str, /, *, is_error: bool = True) -> None:  # noqa: ARG002
+    def error(self, message: str, /, *, is_error: bool = True) -> None:
+        if is_error:
+            self._error_message = message
         print(f"error: {message}", file=sys.stderr)
 
 
@@ -207,13 +214,16 @@ def _import_cookies_from_browser(*, browser: str, cookies_file: str) -> int:
     from ._vendor._ytdlp_cookies import CHROMIUM_BASED_BROWSERS  # noqa: PLC0415
     from ._vendor._ytdlp_cookies import extract_cookies_from_browser  # noqa: PLC0415
 
+    logger = _CookieExtractionLogger()
     browser_cookies = [
         cookie
-        for cookie in extract_cookies_from_browser(
-            browser, logger=_CookieExtractionLogger()
-        )
+        for cookie in extract_cookies_from_browser(browser, logger=logger)
         if cookie.domain == "google.com" or cookie.domain.endswith(".google.com")
     ]
+    # Some keyring backends catch exceptions and fall back to an empty password.
+    # A reported error must prevent even apparently decrypted cookies being saved.
+    if logger.error_message is not None:
+        raise DownloadError(logger.error_message)
     if browser in CHROMIUM_BASED_BROWSERS:
         for cookie in browser_cookies:
             # Chromium stores expiry as microseconds since 1601 and the

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -17,6 +17,7 @@ import pytest
 import requests
 from urllib3.response import HTTPResponse
 
+from gdown._vendor import _ytdlp_cookies
 from gdown._vendor._ytdlp_cookies import extract_cookies_from_browser
 from gdown.download import CHUNK_SIZE
 from gdown.download import GoogleDriveFileToDownload
@@ -590,6 +591,65 @@ def test_cookie_extraction_logger_prints_once_flagged_warning_once(
         logger.warning("cannot decrypt v10 cookies", only_once=True)
 
     assert capsys.readouterr().err == "warning: cannot decrypt v10 cookies\n"
+
+
+def test_import_cookies_preserves_saved_session_when_keyring_fails(
+    *, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    browser_dir = tmp_path / "google-chrome"
+    browser_dir.mkdir()
+    with contextlib.closing(sqlite3.connect(browser_dir / "Cookies")) as connection:
+        connection.executescript("""
+            CREATE TABLE meta (key TEXT, value TEXT);
+            INSERT INTO meta VALUES ('version', '24');
+            CREATE TABLE cookies (
+                host_key TEXT, name TEXT, value TEXT, encrypted_value BLOB,
+                path TEXT, expires_utc INTEGER, is_secure INTEGER
+            );
+        """)
+        # Chromium v11 AES-CBC, password "fake-test-password", with the
+        # SHA-256 domain prefix and value "synthetic-session-0". With the
+        # empty fallback key, upstream incorrectly decrypts this to "".
+        encrypted = bytes.fromhex(
+            "7631317d9727dcf42640993c7a4cb5470827b2505447ffb2a13eda65c440ce0b1e7ec"
+            "6576f2642dc4b97fa9af8b8b08d029110b48cec0cd9cc55496bce5b94a62da87e"
+        )
+        connection.execute(
+            "INSERT INTO cookies VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (".google.com", "SID", "", encrypted, "/", 15746918400000000, 1),
+        )
+        connection.commit()
+
+    cookies_file = tmp_path / "cookies.txt"
+    _save_cookies(
+        cookies=[build_google_cookie(name="SID", value="existing-good-session")],
+        cookies_file=str(cookies_file),
+    )
+    original = cookies_file.read_bytes()
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CURRENT_DESKTOP", "GNOME")
+    monkeypatch.setattr(_ytdlp_cookies, "secretstorage", None)
+
+    with pytest.raises(DownloadError, match="secretstorage not available"):
+        _import_cookies_from_browser(browser="chrome", cookies_file=str(cookies_file))
+
+    assert cookies_file.read_bytes() == original
+
+    with unittest.mock.patch.object(
+        _ytdlp_cookies,
+        "_get_gnome_keyring_password",
+        return_value=b"fake-test-password",
+    ):
+        assert (
+            _import_cookies_from_browser(
+                browser="chrome", cookies_file=str(cookies_file)
+            )
+            == 1
+        )
+    assert [
+        (c.name, c.value) for c in _load_cookies(cookies_file=str(cookies_file))
+    ] == [("SID", "synthetic-session-0")]
 
 
 def test_import_cookies_from_browser_converts_chromium_expiry(


### PR DESCRIPTION
A GNOME Chromium import without `secretstorage` can replace a working saved session cookie with an empty value while reporting success. The vendored extractor logs the keyring failure, falls back to an empty password, and can accept the resulting invalid plaintext. This fixes the blocker found during the 6.2.0 release audit.

Check reported extraction errors before persisting any cookies. The check happens after extraction because some keyring backends catch exceptions internally; raising only from the logger would not reliably stop an import. The vendored source remains unchanged.

The regression test uses a synthetic Chromium SQLite database and valid v11 ciphertext: the missing-keyring case must preserve the saved file byte-for-byte, and the same ciphertext with the correct key must import successfully. It failed before the fix and passes afterward; no real browser profile or keychain is accessed.

Validation: `make lint` and all 121 offline tests pass locally. Live browser/keychain testing was not performed.

Optional SecretStorage installation support is provided separately in #505.
