### PR TITLE
refactor: declare folder entries as dataclass fields

### DIFF
--- a/changelog.d/506.changed.md
+++ b/changelog.d/506.changed.md
@@ -1,0 +1,1 @@
+Declare folder-listing entries as dataclasses while preserving child-list initialization and identity semantics.

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -36,7 +36,7 @@ class _GoogleDriveFile:
 
     def __post_init__(self) -> None:
         if self.children is None:
-            self.children = []  # noqa: GR012 -- preserve legacy None initialization of this schema field
+            self.children = []
 
     def is_folder(self) -> bool:
         return self.type == self.TYPE_FOLDER

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -5,7 +5,10 @@ import os.path as osp
 import re
 import sys
 import urllib.parse
+from dataclasses import dataclass
+from dataclasses import field
 from http import HTTPStatus
+from typing import ClassVar
 from typing import Final
 
 import bs4
@@ -19,24 +22,21 @@ from .exceptions import DownloadError
 from .parse_url import _parse_google_drive_folder_id
 
 
+@dataclass(eq=False, kw_only=True)
 class _GoogleDriveFile:
-    TYPE_FOLDER: Final = "application/vnd.google-apps.folder"
-    TYPE_DOCUMENT: Final = "application/vnd.google-apps.document"
-    TYPE_SPREADSHEET: Final = "application/vnd.google-apps.spreadsheet"
-    TYPE_PRESENTATION: Final = "application/vnd.google-apps.presentation"
+    TYPE_FOLDER: ClassVar[str] = "application/vnd.google-apps.folder"  # noqa: GR004 -- ClassVar keeps constants out of dataclass fields on Python 3.10
+    TYPE_DOCUMENT: ClassVar[str] = "application/vnd.google-apps.document"  # noqa: GR004 -- ClassVar keeps constants out of dataclass fields on Python 3.10
+    TYPE_SPREADSHEET: ClassVar[str] = "application/vnd.google-apps.spreadsheet"  # noqa: GR004 -- ClassVar keeps constants out of dataclass fields on Python 3.10
+    TYPE_PRESENTATION: ClassVar[str] = "application/vnd.google-apps.presentation"  # noqa: GR004 -- ClassVar keeps constants out of dataclass fields on Python 3.10
 
-    def __init__(
-        self,
-        *,
-        id: str,
-        name: str,
-        type: str,
-        children: list[_GoogleDriveFile] | None = None,
-    ) -> None:
-        self.id = id
-        self.name = name
-        self.type = type
-        self.children = children if children is not None else []
+    id: str
+    name: str
+    type: str
+    children: list[_GoogleDriveFile] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.children is None:
+            self.children = []  # noqa: GR012 -- preserve legacy None initialization of this schema field
 
     def is_folder(self) -> bool:
         return self.type == self.TYPE_FOLDER

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ markers = ["network: tests that require network access (Google Drive, GitHub)"]
 
 [tool.gruff.lint]
 select = ["GR"]
+per-file-ignores = { "gdown/_vendor/_ytdlp_cookies.py" = ["GR"] }
 
 [tool.ruff]
 extend-exclude = ["gdown/_vendor/_ytdlp_cookies.py"]

--- a/tests/test_download_folder.py
+++ b/tests/test_download_folder.py
@@ -612,3 +612,29 @@ def test_download_folder_preserves_user_agent(
         assert "Chrome/39" in agents[1]
     else:
         assert agents == [user_agent, user_agent]
+
+
+def test_drive_file_owns_default_children_and_keeps_supplied_list() -> None:
+    first = _GoogleDriveFile(id="a", name="a", type=_GoogleDriveFile.TYPE_FOLDER)
+    second = _GoogleDriveFile(id="b", name="b", type=_GoogleDriveFile.TYPE_FOLDER)
+    supplied = [first]
+    parent = _GoogleDriveFile(
+        id="parent", name="parent", type=_GoogleDriveFile.TYPE_FOLDER, children=supplied
+    )
+    legacy = _GoogleDriveFile(
+        id="legacy",
+        name="legacy",
+        type=first.type,
+        children=None,  # ty: ignore[invalid-argument-type] -- legacy callers supplied None
+    )
+    first.children.append(second)
+    assert legacy.children == []
+    assert second.children == []
+    assert parent.children is supplied
+    assert first.is_folder()
+    assert not first.is_google_native()
+    assert first != _GoogleDriveFile(
+        id="a", name="a", type=first.type, children=first.children
+    )
+    with pytest.raises(TypeError):
+        _GoogleDriveFile(id="a", name="a", type=first.type, TYPE_FOLDER="overridden")  # ty: ignore[unknown-argument] -- verify runtime rejection


### PR DESCRIPTION
Make the folder data carrier explicit as part of [Gruff #85](https://github.com/wkentaro/gruff/issues/85). The migration preserves identity equality, keyword-only construction, caller-supplied child-list identity, fresh defaults, and runtime acceptance of legacy `children=None`. ClassVar annotations keep MIME constants out of generated fields on supported Python 3.10.

Legacy None normalization now needs no GR012 suppression because the field is declared in the class body. Vendored output is ignored in Gruff configuration; the project-owned generator remains checked. The private constructor’s static annotation advertises a list, while None remains accepted at runtime.

Validation: 122 non-network tests and `make lint` passed on the final source. Two Google Drive integration tests previously returned empty folder listings on both this branch and untouched `dacdd945e83d`; the network suite was not rerun in this iteration.

With the revised GR012, raw findings decrease from the original 12 to eight; configured findings decrease to five, all in the generator. No visual evidence is needed for this internal data-model change; the constructor regression test and linter comparison exercise the changed contracts. See Gruff #85 for pinned results and remaining adoption work.
