### PR TITLE
chore: adopt gruff 0.0.10 and exclude vendored code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ format:  # Format code
 lint:  # Lint code
 	$(call exec,uv run ruff format --check)
 	$(call exec,uv run ruff check)
-	$(call exec,uv run gruff check $(shell git ls-files "*.py" ":!gdown/_vendor/_ytdlp_cookies.py"))
+	$(call exec,uv run gruff check $(shell git ls-files "*.py" ":!gdown/_vendor/**"))
 	$(call exec,uv run ty check --no-progress)
 	$(call exec,uv run taplo fmt --check $(shell git ls-files "*.toml"))
 	$(call exec,uv run mdformat --check $(shell git ls-files "*.md"))

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,5 +1,5 @@
 [files]
-extend-exclude = ["tests/data/", "gdown/_vendor/_ytdlp_cookies.py"]
+extend-exclude = ["tests/data/", "gdown/_vendor/"]
 
 [default.extend-words]
 # Substrings in Google Drive file IDs

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -5,7 +5,10 @@ import os.path as osp
 import re
 import sys
 import urllib.parse
+from dataclasses import dataclass
+from dataclasses import field
 from http import HTTPStatus
+from typing import ClassVar
 from typing import Final
 
 import bs4
@@ -19,29 +22,19 @@ from .exceptions import DownloadError
 from .parse_url import _parse_google_drive_folder_id
 
 
+@dataclass(kw_only=True, eq=False)
 class _GoogleDriveFile:
     id: str
     name: str
     type: str
-    children: list[_GoogleDriveFile]
+    children: list[_GoogleDriveFile] = field(default_factory=list)
 
-    TYPE_FOLDER: Final = "application/vnd.google-apps.folder"
-    TYPE_DOCUMENT: Final = "application/vnd.google-apps.document"
-    TYPE_SPREADSHEET: Final = "application/vnd.google-apps.spreadsheet"
-    TYPE_PRESENTATION: Final = "application/vnd.google-apps.presentation"
-
-    def __init__(
-        self,
-        *,
-        id: str,
-        name: str,
-        type: str,
-        children: list[_GoogleDriveFile] | None = None,
-    ) -> None:
-        self.id = id
-        self.name = name
-        self.type = type
-        self.children = children if children is not None else []
+    # Python versions below 3.13 cannot combine class-variable and final
+    # annotations; these constants must stay out of the generated constructor.
+    TYPE_FOLDER: ClassVar[str] = "application/vnd.google-apps.folder"  # noqa: GR004
+    TYPE_DOCUMENT: ClassVar[str] = "application/vnd.google-apps.document"  # noqa: GR004
+    TYPE_SPREADSHEET: ClassVar[str] = "application/vnd.google-apps.spreadsheet"  # noqa: GR004
+    TYPE_PRESENTATION: ClassVar[str] = "application/vnd.google-apps.presentation"  # noqa: GR004
 
     def is_folder(self) -> bool:
         return self.type == self.TYPE_FOLDER

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -20,6 +20,11 @@ from .parse_url import _parse_google_drive_folder_id
 
 
 class _GoogleDriveFile:
+    id: str
+    name: str
+    type: str
+    children: list[_GoogleDriveFile]
+
     TYPE_FOLDER: Final = "application/vnd.google-apps.folder"
     TYPE_DOCUMENT: Final = "application/vnd.google-apps.document"
     TYPE_SPREADSHEET: Final = "application/vnd.google-apps.spreadsheet"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Homepage = "https://github.com/wkentaro/gdown"
 
 [dependency-groups]
 dev = [
-  "gruff>=0.0.6",
+  "gruff>=0.0.10",
   "mdformat>=0.7.17",
   "pytest>=8.3.5",
   "pytest-xdist>=3.6.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,10 +85,10 @@ markers = ["network: tests that require network access (Google Drive, GitHub)"]
 select = ["GR"]
 
 [tool.ruff]
-extend-exclude = ["gdown/_vendor/_ytdlp_cookies.py"]
+extend-exclude = ["gdown/_vendor/"]
 
 [tool.ty.src]
-exclude = ["gdown/_vendor/_ytdlp_cookies.py"]
+exclude = ["gdown/_vendor/"]
 
 [tool.ruff.lint]
 extend-select = [

--- a/scripts/vendor_ytdlp_cookies.py
+++ b/scripts/vendor_ytdlp_cookies.py
@@ -27,13 +27,19 @@ OUT: Final = (
 
 
 class Module:
+    name: str
+    lines: list[str]
+    body: list[ast.stmt]
+    defs: dict[str, ast.stmt]
+    # bound name -> (relative module or None, upstream name, import node)
+    imports: dict[str, tuple[str | None, str, ast.stmt]]
+
     def __init__(self, *, name: str, source: str) -> None:
         self.name = name
         self.lines = source.splitlines(keepends=True)
         self.body = ast.parse(source).body
-        self.defs: dict[str, ast.stmt] = {}
-        # bound name -> (relative module or None, upstream name, import node)
-        self.imports: dict[str, tuple[str | None, str, ast.stmt]] = {}
+        self.defs = {}
+        self.imports = {}
         for node in self.body:
             if isinstance(node, ast.Import | ast.ImportFrom):
                 module = None

--- a/uv.lock
+++ b/uv.lock
@@ -417,7 +417,7 @@ provides-extras = ["secretstorage"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "gruff", specifier = ">=0.0.6" },
+    { name = "gruff", specifier = ">=0.0.10" },
     { name = "mdformat", specifier = ">=0.7.17" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
@@ -431,14 +431,14 @@ dev = [
 
 [[package]]
 name = "gruff"
-version = "0.0.6"
+version = "0.0.10"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/a7/0d517a09090571daa8bf19928a8a9481e1b0c5a1a79366febc23162f7d07/gruff-0.0.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ba23fe2c1ca1bf4b0033325c3c9c12d778757b5ccc3f991f6942b716d9b45557", size = 1999075, upload-time = "2026-09-02T06:26:00.505Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/97/3a550fe81f2ab03836e1a8fd986904b170d8173aee858dd2bbfb018f29fd/gruff-0.0.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d884fb3b934c577d246de24d9c978be78d90f67dfed02c17e43eb1d1745aee36", size = 1931385, upload-time = "2026-09-02T06:26:02.348Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/a6/d15878075937223819b41627164de9b39588497cda8e5d7a354aca084c7a/gruff-0.0.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28b1ecf709668088af42d3098be5786b608835ccbae17f9e4ac0c4aa434f0e44", size = 1951056, upload-time = "2026-09-02T06:26:03.793Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/38/d2eb584c4d905f3ad08ec0881b0af0ec358cd7dcbedc01f3cfef644835cb/gruff-0.0.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51e9ac387ddac9fb3b6c487a62afce556c05b4012f4e04863c664dec602ab1de", size = 2072288, upload-time = "2026-09-02T06:26:05.228Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/c3/fbf10396f2043a097e65a5fa723371dc5b2e1613f6284185aba1043cd78e/gruff-0.0.6-py3-none-win_amd64.whl", hash = "sha256:1cee0319fc3ce22e23cadb9483fe93515551b4856d4a1ae94d8745329e88d33d", size = 1977267, upload-time = "2026-09-02T06:26:06.579Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/7e96f6a52854c60308cb5a07c3d4109727347dd8da2e7cd1cab81739c2b3/gruff-0.0.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4a6351ef3d046224b856a1b5bad74ff2d7695ea8935d5090bfb182aa6ac78106", size = 2019870, upload-time = "2026-09-07T02:31:25.891Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8f/8b120b35029b0122b5a695c31d741b3e650fb8bb91a2769a4eb41c9c54c4/gruff-0.0.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:de9f7154e371feeebaf6d88282d512dc29eca5e916bac307924b264d754db487", size = 1951377, upload-time = "2026-09-07T02:31:27.779Z" },
+    { url = "https://files.pythonhosted.org/packages/36/33/7d35bade2093959c4205bb05bb357cdc4d79ebf8463b7f49e8d1e82d992b/gruff-0.0.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0c22cfa526a5ff3fc5577cba4dd3b4492f941ccf67b664a7c95ba0516c7a67e", size = 1970604, upload-time = "2026-09-07T02:31:29.663Z" },
+    { url = "https://files.pythonhosted.org/packages/46/a3/94d5a30aa8dcc7a0f69e70ef1491b6a263853cea3d6c7fff096deaee79bf/gruff-0.0.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b1889578bb75302bbea5234c39ddde49120344f10634b8333473bc4e2f26213", size = 2094056, upload-time = "2026-09-07T02:31:31.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/16/0f5d14f2bf5518aa261c7896c1c93dec66b1878f8c6a5abbe5f699692c73/gruff-0.0.10-py3-none-win_amd64.whl", hash = "sha256:9e2495e84247df4fa5067dabe6272a0037403f3b8fdafc71f25840c282b877af", size = 2001509, upload-time = "2026-09-07T02:31:33.046Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adopts Gruff 0.0.10 with all GR rules enabled and excludes the entire vendored directory from code checks. Satisfies GR012 by declaring the parser's existing instance fields and converting folder entries to a keyword-only dataclass.

The dataclass keeps identity equality and allocates a separate children list per instance. Existing callers omit children or supply a list. MIME constants use class-variable annotations to keep them out of the generated constructor; their GR004 suppressions are needed because Python versions below 3.13 cannot combine class-variable and final annotations.

Validation: `make lint`, `uv lock --check`, and all 121 offline tests passed on macOS with Python 3.10.19. Network tests were not run.

Additional media omitted: there is no visual change, and the diff plus validation cover the update.
